### PR TITLE
Feature/gpu linear solver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,20 @@
 - Operate autonomously for this goal: you do not need additional approval to build, run, and iterate within this mirror. Keep CPU behaviour identical unless GPU is explicitly selected.
 - Safety rails: if a GPU trial exceeds 10 minutes, diverges, or fails the parity gate, revert to the safe path (diagonal preconditioner, CPU fallback) and iterate.
 
+**PLAN (current execution order)**
+1. Add a coloured GPU preconditioner:
+   - Build colour sets from the pressure matrix addressing and launch per-colour forward/back sweeps with damping.
+   - Auto-fallback to the diagonal preconditioner if divergence or instability is detected.
+2. Reduce CG iteration overhead:
+   - Implement a pipelined CG variant that fuses dot products/reductions.
+   - Capture the steady-state kernel sequence in a CUDA Graph to trim launch latency (retain the legacy path as a runtime switch).
+3. Keep the full PIMPLE loop on the GPU:
+   - Extend `pimpleFoamGPU` so ddt/div/laplacian kernels, turbulence `correct()`, and Courant calculations operate on device-resident fields.
+   - Copy results back only at write times; CPU path remains untouched.
+4. Validate on the standard pitzDaily case:
+   - Confirm parity (relative L2(Ux) ≤ 1e-2) and measure wall-clock vs the 35 s CPU baseline.
+   - Iterate until the GPU path beats the CPU timing or no further practical improvements are found.
+
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,13 @@
 - With GPU acceleration as the target, proceed without seeking further permission; execute all necessary steps inside this mirror to progress the optimisation.
 - Continue iterating until you exhaust practical improvements, then deliver a single comprehensive report rather than intermediate status updates.
 
+**End-to-End GPU Goal (Phase 2+)**
+- Do not modify or regress the CPU implementation. Treat `/opt/openfoam10` and branch `main` as the stable CPU baseline; use runtime selection/feature flags for all GPU work.
+- Target: implement the entire PIMPLE loop on the GPU (assembly, turbulence updates, reductions, linear solves) and beat the CPU wall-clock (≈35 s on pitzDaily) on the same case and hardware while preserving parity (relative L2(Ux) ≤ 1e-2 at final time).
+- Prioritise changes that reduce end-to-end GPU time over negligible micro-optimisations.
+- Operate autonomously for this goal: you do not need additional approval to build, run, and iterate within this mirror. Keep CPU behaviour identical unless GPU is explicitly selected.
+- Safety rails: if a GPU trial exceeds 10 minutes, diverges, or fails the parity gate, revert to the safe path (diagonal preconditioner, CPU fallback) and iterate.
+
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,18 +49,19 @@
 - Safety rails: if a GPU trial exceeds 10 minutes, diverges, or fails the parity gate, revert to the safe path (diagonal preconditioner, CPU fallback) and iterate.
 
 **PLAN (current execution order)**
-1. Stabilise and benchmark the coloured GPU preconditioner:
-   - **Status:** pitzDaily sweep complete (`run/logs/pitzDaily_gpu_colour_scan2_20251012-150314/summary.csv`). All runs stayed on the colour path (`disableCount=0`).
-   - Recommended defaults baked into `cudaPCG`: `colourOmega=0.65`, `colourBackwardOmega=0.85`, `colourDiagFloor=1e-12` (details in `docs/gpu-colour-preconditioner-20251012.md`).
-   - Telemetry/logging (`logResidualTrajectory`, `logColourStats`) and sweep script (`bin/gpu_colour_sweep.sh`) ready for future validation cases.
-2. Reduce CG iteration overhead (infrastructure ready):
-   - Pipelined direction update (`usePipelinedCG`), CUDA Graph replay (`useCudaGraph`), and iteration timing (`logIterationStats`) are available. Grid sweep (`run/logs/pitzDaily_gpu_colour_grid_small_*`) indicates ω_fwd≈0.65, ω_back≈0.80 is a good compromise (~77 iterations, rel L2≈3.2e-5, ExecutionTime ≈231 s). Further heuristics deferred until the full GPU loop is in place.
-3. Full GPU PIMPLE loop (next focus):
-   - Keep volume fields resident on device; port ddt/div/laplacian kernels, turbulence `correct()`, and Courant/time-step logic into CUDA.
-   - Only copy data back at write times; CPU path remains untouched when GPU is disabled.
-4. End-to-end validation & regression guards:
-   - Extend sweep scripts to capture wall-clock and enforce parity/iteration/time thresholds (via `bin/check_colour_summary.py`).
-   - Benchmark pitzDaily (and a secondary case) to drive the GPU loop below the 35 s CPU baseline while keeping relative L2(Ux) ≤ 1e-2.
+1. **GPU finite-volume operators**
+   - Port `fvm::ddt`, `fvm::div(phi,U)`, and `fvm::laplacian(rAtU(),p)` to dedicated CUDA kernels that operate on the existing device-resident field wrappers.
+   - Mirror boundary-condition handling from the CPU path; ensure the kernels accept runtime-selected discretisation schemes.
+   - Integrate the kernels into `pimpleFoamGPU`, keeping the CPU implementation intact behind `useGpuFieldOps=false`.
+2. **Turbulence and source-term GPU path**
+   - Implement a CUDA-backed turbulence `correct()` (RAS initially) and any dependent algebra so turbulence fields remain on-device.
+   - Audit additional source terms (fvModels/fvConstraints) and provide GPU fallbacks or staged host/device copies as needed.
+3. **Kernel orchestration & caching**
+   - Extend the GPU infrastructure to cache NVRTC output per compute capability, batch small vector ops via CUDA Graphs, and introduce multi-stream execution where overlap with host IO is possible.
+   - Add SoA-friendly accessors or layouts for vector fields if profiling shows strided loads as a bottleneck.
+4. **Profiling, validation, and regression**
+   - Expand the timing CSV exports to include every new kernel; feed the data into the benchmark script for automated speed reports.
+   - Maintain `run/scripts/run_gpu_parity.sh` as the correctness gate and push `run/scripts/benchmark_gpu_speed.sh` below the ~35 s CPU baseline on pitzDaily before considering deployment.
 
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,11 @@
    - Batch short kernels (ddt/div/laplacian/nut, etc.) via CUDA Graphs to cut launch overhead.
    - Introduce multi-stream execution to overlap device kernels with host-side assembly/reduction work.
    - Add optional SoA-friendly accessors or layouts if profiling flags strided-load penalties.
+   - **GPU pressure solver bring-up plan:**
+     - Capture residual/iteration traces for the current `cudaPCG` path (enable `reportGpuStats`/`logResidualTrajectory`) and profile with Nsight/`nvprof` to pinpoint stalls.
+     - Stabilise the GPU preconditioner: finish the cuSPARSE-based SGS/DIC path (or fix the coloured smoother) so convergence matches the CPU reference; guard all failures with a fast diagonal fallback.
+     - Re-enable the `cudaPCG` runtime selection once convergence matches the CPU shadow solve, keeping the watchdog/CPU fallback in place.
+     - Profile the fixed solver and apply the orchestration hooks (CUDA Graphs, multi-stream overlap) to drive end-to-end GPU wall time below the ~35 s CPU baseline.
 4. **Profiling, validation, and regression**
    - Expand timing CSV outputs to cover every GPU kernel and turbulence step; feed these into the benchmark scripts for automated reporting.
    - Maintain the parity harness (`run/scripts/run_gpu_parity.sh`) and push `run/scripts/benchmark_gpu_speed.sh` below the ~35 s CPU baseline before deployment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,10 @@
 - Don’t change core header names/locations without updating all dependents.
 - Don’t push experimental binaries into `/opt`. Keep experiments within this mirror.
 
+**Autonomous Execution**
+- With GPU acceleration as the target, proceed without seeking further permission; execute all necessary steps inside this mirror to progress the optimisation.
+- Continue iterating until you exhaust practical improvements, then deliver a single comprehensive report rather than intermediate status updates.
+
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+**Scope**
+- Applies to `/home/xiaozhou/OpenFOAM/openfoam10-gpu` (user-owned development mirror of OpenFOAM v10).
+- Do not modify `/opt/openfoam10` during development; treat it as a stable CPU baseline.
+
+**CPU-As-Reference**
+- Preserve public APIs and behaviour; add GPU code paths via feature flags or run‑time selection.
+- Validate GPU results against the existing CPU reference cases (pitzDaily CPU run) before deployment.
+
+**Git Workflow**
+- Branches: `main` mirrors the CPU baseline; `gpu` is the active development branch.
+- Keep changes minimal and focused; avoid unrelated refactors. Use conventional commits.
+- Do not commit build artefacts (`platforms/*`, `*/lnInclude/`, `Make/*/*`, logs).
+
+**Build & Environment**
+- Source this tree when building or running GPU trials: `. etc/bashrc` (sets `WM_PROJECT_DIR`, paths).
+- Full build: `./Allwmake`
+- Targeted library: `wmake libso src/<libPath>`
+- If link errors occur, try `wclean libso src/<libPath>` then rebuild. If ABI/symbol issues persist, `wclean all && ./Allwmake`.
+
+**Deployment Gate (copying to /opt)**
+- Only deploy changes into `/opt/openfoam10` when ALL of the following pass:
+  - Build completes without errors in this mirror.
+  - A pitzDaily GPU trial runs to completion from a clean case.
+  - Comparison vs CPU reference meets parity target (see run AGENTS.md: last time step U, relative L2 threshold).
+- Request approval before any write to `/opt` and avoid overwriting stock files unnecessarily.
+
+**Reset Triggers (Build)**
+- Two consecutive link/ABI errors after targeted clean → run `wclean all && ./Allwmake`.
+- Stale header or symbol mismatches → remove `lnInclude` directories and rebuild.
+- Build log grows >50MB without progress, or compile time >2× usual → abort and do a clean rebuild.
+
+**Logs & Artefacts**
+- Save `log.Allwmake` into `/home/xiaozhou/OpenFOAM/build_logs/<timestamp>.log` for later triage.
+- Capture exact compiler flags (store `wmake/rules` diffs if modified).
+
+**Don’ts**
+- Don’t change core header names/locations without updating all dependents.
+- Don’t push experimental binaries into `/opt`. Keep experiments within this mirror.
+
+
+---
+
+GPU Linear Solver Development (Phase 1)
+--------------------------------------
+
+- Branching
+  - Active feature branch for Phase 1: `feature/gpu-linear-solver` (base: `gpu`).
+  - Use conventional commits; keep changes minimal and additive.
+
+- Toolchain
+  - Before GPU builds/runs, check: `tools/check_gpu_toolchain.sh`.
+  - CUDA path currently assumes `/usr/local/cuda` in `src/MomentumTransportModels/**/Make/options`.
+    - If CUDA is elsewhere, set up symlink or adjust Make/options locally.
+    - CPU fallback must remain operational if CUDA is not present.
+
+- Build
+  - Source environment from this mirror: `. etc/bashrc`.
+  - To keep dev builds green, PVReaders is optional: export `WM_NOCMAKE=on` when running `./Allwmake` or avoid building `applications/utilities/postProcessing/graphics`.
+  - Targeted builds:
+    - Core matrices/solvers will live under `src/OpenFOAM/matrices/lduMatrix/solvers/` (e.g., `cudaPCG`).
+    - Use `wmake libso` on the corresponding library when iterating.
+
+- Runtime selection (planned)
+  - A new `lduMatrix::solver` (e.g., `cudaPCG`) will be selectable via `system/fvSolution`.
+  - If the GPU solver/backend is unavailable or disabled, runtime must fall back to the CPU solver without errors.
+  - When using the new solver, ensure the library is loaded via `system/controlDict`:
+    - `libs ("libcudaPCG.so");`
+
+- Validation
+  - Use `run/scripts/run_gpu_trial.sh pitzDaily_gpu<N> <mirror> 1e-2`.
+  - Acceptance gate: pitzDaily runs to completion; relative L2(Ux) ≤ 1e-2 at the last time.
+  - Record timings for solver phases to track speedups.
+
+- Deployment
+  - Follow existing deployment gate. Do not copy into `/opt/openfoam10` until all gates pass. Copy only minimal changed files; request approval first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,19 +49,28 @@
 - Safety rails: if a GPU trial exceeds 10 minutes, diverges, or fails the parity gate, revert to the safe path (diagonal preconditioner, CPU fallback) and iterate.
 
 **PLAN (current execution order)**
-1. **GPU finite-volume operators**
-   - Port `fvm::ddt`, `fvm::div(phi,U)`, and `fvm::laplacian(rAtU(),p)` to dedicated CUDA kernels that operate on the existing device-resident field wrappers.
-   - Mirror boundary-condition handling from the CPU path; ensure the kernels accept runtime-selected discretisation schemes.
-   - Integrate the kernels into `pimpleFoamGPU`, keeping the CPU implementation intact behind `useGpuFieldOps=false`.
-2. **Turbulence and source-term GPU path**
-   - Implement a CUDA-backed turbulence `correct()` (RAS initially) and any dependent algebra so turbulence fields remain on-device.
-   - Audit additional source terms (fvModels/fvConstraints) and provide GPU fallbacks or staged host/device copies as needed.
-3. **Kernel orchestration & caching**
-   - Extend the GPU infrastructure to cache NVRTC output per compute capability, batch small vector ops via CUDA Graphs, and introduce multi-stream execution where overlap with host IO is possible.
-   - Add SoA-friendly accessors or layouts for vector fields if profiling shows strided loads as a bottleneck.
+1. **GPU finite-volume operators** *(completed)*
+   - Device variants for `fvm::ddt`, `fvm::div(phi,U)`, and `fvm::laplacian(rAtU(),p)` are in place and gated by `PIMPLE.useGpuFieldOps`.
+   - Boundary handling mirrors the CPU schemes; CPU fallback remains active when the GPU flag is unset or the context fails.
+2. **Turbulence GPU path** *(completed for k‑ε)*
+   - `kEpsilon::correct()` now updates `k`, `epsilon`, and `nut` on-device via `gpu::computeNutFromKEpsilon`, with boundary updates and host fallback intact.
+   - Keep auditing additional RAS variants/fvModels when they appear; mirror the same device-field pattern to avoid host/device thrash.
+3. **Kernel orchestration & caching** *(next active step)*
+   - Cache NVRTC output per compute capability so repeated launches reuse compiled PTX/fatbins.
+   - Batch short kernels (ddt/div/laplacian/nut, etc.) via CUDA Graphs to cut launch overhead.
+   - Introduce multi-stream execution to overlap device kernels with host-side assembly/reduction work.
+   - Add optional SoA-friendly accessors or layouts if profiling flags strided-load penalties.
 4. **Profiling, validation, and regression**
-   - Expand the timing CSV exports to include every new kernel; feed the data into the benchmark script for automated speed reports.
-   - Maintain `run/scripts/run_gpu_parity.sh` as the correctness gate and push `run/scripts/benchmark_gpu_speed.sh` below the ~35 s CPU baseline on pitzDaily before considering deployment.
+   - Expand timing CSV outputs to cover every GPU kernel and turbulence step; feed these into the benchmark scripts for automated reporting.
+   - Maintain the parity harness (`run/scripts/run_gpu_parity.sh`) and push `run/scripts/benchmark_gpu_speed.sh` below the ~35 s CPU baseline before deployment.
+5. **Boundary conditions & supplementary sources**
+   - Port common BCs (fixedValue, zeroGradient, inletOutlet, wall functions) and fvModel/fvConstraint sources to the GPU to eliminate forced fallbacks.
+   - Extend turbulence GPU coverage beyond νₜ if additional scalars/models are required.
+6. **Multi-GPU (MPI)**
+   - Add CUDA-aware halo exchanges (optionally GPUDirect) so decomposed runs keep fields resident; overlap comm/compute while preserving existing run scripts.
+7. **Hardening & docs**
+   - Wire CI hooks to build CPU+GPU targets, run pitzDaily, compare fields, and trend timings.
+   - Document the runtime flags (`PIMPLE.useGpuFieldOps`, turbulence `useGPU`, etc.) and finalise the deployment checklist before copying into `/opt/openfoam10`.
 
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@
    - Recommended defaults baked into `cudaPCG`: `colourOmega=0.65`, `colourBackwardOmega=0.85`, `colourDiagFloor=1e-12` (details in `docs/gpu-colour-preconditioner-20251012.md`).
    - Telemetry/logging (`logResidualTrajectory`, `logColourStats`) and sweep script (`bin/gpu_colour_sweep.sh`) ready for future validation cases.
 2. Reduce CG iteration overhead:
-   - **Status:** pipelined search-direction update (`usePipelinedCG`) landed; steady-state `cusparseSpMV` replay captured via CUDA Graph when `useCudaGraph` is true (`cudaGraphWarmup` configurable).
-   - Pipelined smoke log: `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/summary.csv` (rel L2(Ux)≈3.3e-5, 785 iterations, ExecutionTime ≈245 s). Leave toggle opt-in until tuning recovers parity/run-time.
+   - **Status:** pipelined search-direction update (`usePipelinedCG`) landed; steady-state `cusparseSpMV` replay captured via CUDA Graph when `useCudaGraph` is true (`cudaGraphWarmup` configurable). Iteration timing available via `logIterationStats`.
+   - Pipelined smoke log: `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/summary.csv` (rel L2(Ux)≈3.3e-5, ExecutionTime ≈245 s).
+   - New grid sweep (ω_fwd∈[0.50..0.65], ω_back∈[0.70..0.85]) under `run/logs/pitzDaily_gpu_colour_grid_small_*` shows ω_fwd≈0.65, ω_back≈0.80 drops PCG iterations to ≈77 while keeping rel L2≈3.2e-5 (ExecTime ≈231 s). Further tuning required to regain the ~116 s baseline.
 3. Keep the full PIMPLE loop on the GPU:
    - Extend `pimpleFoamGPU` so ddt/div/laplacian kernels, turbulence `correct()`, and Courant calculations operate on device-resident fields.
    - Copy results back only at write times; CPU path remains untouched.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,16 +53,14 @@
    - **Status:** pitzDaily sweep complete (`run/logs/pitzDaily_gpu_colour_scan2_20251012-150314/summary.csv`). All runs stayed on the colour path (`disableCount=0`).
    - Recommended defaults baked into `cudaPCG`: `colourOmega=0.65`, `colourBackwardOmega=0.85`, `colourDiagFloor=1e-12` (details in `docs/gpu-colour-preconditioner-20251012.md`).
    - Telemetry/logging (`logResidualTrajectory`, `logColourStats`) and sweep script (`bin/gpu_colour_sweep.sh`) ready for future validation cases.
-2. Reduce CG iteration overhead:
-   - **Status:** pipelined search-direction update (`usePipelinedCG`) landed; steady-state `cusparseSpMV` replay captured via CUDA Graph when `useCudaGraph` is true (`cudaGraphWarmup` configurable). Iteration timing available via `logIterationStats`.
-   - Pipelined smoke log: `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/summary.csv` (rel L2(Ux)≈3.3e-5, ExecutionTime ≈245 s).
-   - New grid sweep (ω_fwd∈[0.50..0.65], ω_back∈[0.70..0.85]) under `run/logs/pitzDaily_gpu_colour_grid_small_*` shows ω_fwd≈0.65, ω_back≈0.80 drops PCG iterations to ≈77 while keeping rel L2≈3.2e-5 (ExecTime ≈231 s). Further tuning required to regain the ~116 s baseline.
-3. Keep the full PIMPLE loop on the GPU:
-   - Extend `pimpleFoamGPU` so ddt/div/laplacian kernels, turbulence `correct()`, and Courant calculations operate on device-resident fields.
-   - Copy results back only at write times; CPU path remains untouched.
-4. Validate on the standard pitzDaily case:
-   - Confirm parity (relative L2(Ux) ≤ 1e-2) and measure wall-clock vs the 35 s CPU baseline.
-   - Iterate until the GPU path beats the CPU timing or no further practical improvements are found.
+2. Reduce CG iteration overhead (infrastructure ready):
+   - Pipelined direction update (`usePipelinedCG`), CUDA Graph replay (`useCudaGraph`), and iteration timing (`logIterationStats`) are available. Grid sweep (`run/logs/pitzDaily_gpu_colour_grid_small_*`) indicates ω_fwd≈0.65, ω_back≈0.80 is a good compromise (~77 iterations, rel L2≈3.2e-5, ExecutionTime ≈231 s). Further heuristics deferred until the full GPU loop is in place.
+3. Full GPU PIMPLE loop (next focus):
+   - Keep volume fields resident on device; port ddt/div/laplacian kernels, turbulence `correct()`, and Courant/time-step logic into CUDA.
+   - Only copy data back at write times; CPU path remains untouched when GPU is disabled.
+4. End-to-end validation & regression guards:
+   - Extend sweep scripts to capture wall-clock and enforce parity/iteration/time thresholds (via `bin/check_colour_summary.py`).
+   - Benchmark pitzDaily (and a secondary case) to drive the GPU loop below the 35 s CPU baseline while keeping relative L2(Ux) ≤ 1e-2.
 
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,13 @@
 - Safety rails: if a GPU trial exceeds 10 minutes, diverges, or fails the parity gate, revert to the safe path (diagonal preconditioner, CPU fallback) and iterate.
 
 **PLAN (current execution order)**
-1. Add a coloured GPU preconditioner:
-   - Build colour sets from the pressure matrix addressing and launch per-colour forward/back sweeps with damping.
-   - Auto-fallback to the diagonal preconditioner if divergence or instability is detected.
+1. Stabilise and benchmark the coloured GPU preconditioner:
+   - **Status:** pitzDaily sweep complete (`run/logs/pitzDaily_gpu_colour_scan2_20251012-150314/summary.csv`). All runs stayed on the colour path (`disableCount=0`).
+   - Recommended defaults baked into `cudaPCG`: `colourOmega=0.65`, `colourBackwardOmega=0.85`, `colourDiagFloor=1e-12` (details in `docs/gpu-colour-preconditioner-20251012.md`).
+   - Telemetry/logging (`logResidualTrajectory`, `logColourStats`) and sweep script (`bin/gpu_colour_sweep.sh`) ready for future validation cases.
 2. Reduce CG iteration overhead:
-   - Implement a pipelined CG variant that fuses dot products/reductions.
-   - Capture the steady-state kernel sequence in a CUDA Graph to trim launch latency (retain the legacy path as a runtime switch).
+   - **Status:** pipelined search-direction update (`usePipelinedCG`) landed; steady-state `cusparseSpMV` replay captured via CUDA Graph when `useCudaGraph` is true (`cudaGraphWarmup` configurable).
+   - Pipelined smoke log: `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/summary.csv` (rel L2(Ux)≈3.3e-5, 785 iterations, ExecutionTime ≈245 s). Leave toggle opt-in until tuning recovers parity/run-time.
 3. Keep the full PIMPLE loop on the GPU:
    - Extend `pimpleFoamGPU` so ddt/div/laplacian kernels, turbulence `correct()`, and Courant calculations operate on device-resident fields.
    - Copy results back only at write times; CPU path remains untouched.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,227 @@
+# GPU Acceleration Plan for pimpleFoam (OpenFOAM v10 — dev mirror)
+
+This document captures the roadmap to evolve the current GPU-enabled k–ε turbulence model into a broader GPU acceleration for pimpleFoam while preserving CPU APIs and behavior. It is intended for the development mirror at `/home/xiaozhou/OpenFOAM/openfoam10-gpu` and complements AGENTS.md.
+
+## Scope & Principles
+
+- Preserve public APIs and CPU behavior; add GPU as additive runtime-selectable backends.
+- CPU remains the reference; maintain numerical parity against CPU pitzDaily.
+- Work only in this dev mirror; deploy to `/opt/openfoam10` only after gates pass and with approval.
+- Keep changes minimal and focused; conventional commits; no artefacts in VCS.
+
+## Environments & Baseline
+
+- Dev mirror: `/home/xiaozhou/OpenFOAM/openfoam10-gpu` (branch `gpu`).
+- CPU baseline case: `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_cpu`.
+- Clean template: `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_clean`.
+- Scripts: `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts`.
+- Existing GPU: k–ε `nut` update has an optional CUDA path (NVRTC JIT) with CPU fallback.
+
+## Success Criteria & Gates
+
+- Build completes without errors in this mirror.
+  - Note: PVReaders is optional in dev; use `WM_NOCMAKE=on` (or skip PVReaders) to keep dev builds green.
+- pitzDaily GPU trial runs to completion from a clean case using this mirror environment.
+- Numerical parity: relative L2(Ux) at last time step ≤ 1e-2 (threshold configurable by scripts).
+- Deployment to `/opt/openfoam10` only after all gates pass and with explicit approval.
+
+## Measurement & Tooling
+
+- Use `tools/check_gpu_toolchain.sh` to enforce CUDA/HIP presence before GPU builds/runs.
+- Build wrapper: `tools/build_all.sh` (captures logs under `/home/xiaozhou/OpenFOAM/build_logs/`).
+- Run/compare: `run/scripts/run_gpu_trial.sh` + `Calculate_error.py` (auto-picks last time and checks relative L2 with optional per-component stats).
+
+## Phased Roadmap
+
+### Phase 0 — Foundations
+
+- Conditional CUDA build flags (detect `CUDA_HOME` or nvcc; gate `FOAM_USE_CUDA`).
+- Keep PVReaders off in dev builds (e.g., export `WM_NOCMAKE=on` in build script) to avoid unrelated CMake errors.
+- Augment scripts to record timings and iteration counts for U/p solves.
+- Ensure CPU fallback paths are robust and warning-rich.
+
+Deliverables:
+- Make/options conditionals; optional environment toggles (no-op on CPU-only hosts).
+- Build script minor patch (optional): early toolchain check; skip PVReaders.
+
+Acceptance:
+- Mirror builds cleanly for core libs; PVReaders optionally skipped.
+
+### Phase 1 — GPU Linear Solver Offload (single GPU)
+
+Goal: Offload linear solves for `(U|p|k|epsilon)` while keeping assembly on CPU; transfer matrices/vectors to GPU each iteration.
+
+Core tasks:
+- ldu→CSR exporter: build once per mesh change; update coefficients per solve.
+- Implement a GPU solver (default): Custom CUDA PCG/BiCGStab with Jacobi/ILU0 using cuSPARSE/cuSOLVER.
+  - Optional later: AmgX wrapper as an alternative runtime‑selectable backend.
+- Runtime selection: add a new `lduMatrix::solver` type (e.g., `cudaPCG` or `amgx`) selectable via `system/fvSolution`; CPU fallback retained.
+- Logging/timing around solver calls.
+
+Deliverables:
+- New solver under `src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/` (gated by `FOAM_USE_CUDA`).
+- CSR export utilities (mapping indices and data views) with unit-level validation on small matrices.
+- Example `fvSolution` entries (see examples below).
+
+Acceptance:
+- pitzDaily passes parity gate (relative L2(Ux) ≤ 1e-2) with GPU solver.
+- Speedup targets: solver‑only ≥3× for U/p; end‑to‑end ≥1.3× vs CPU on the same mesh.
+
+### Phase 2 — Resident Data Across PIMPLE
+
+Goal: Minimize PCIe transfers by keeping vectors/matrices on device across inner PIMPLE loops.
+
+Core tasks:
+- Device memory manager: mirror arrays for field internals and matrix coefficients; reuse allocations over time steps.
+- Modify GPU solver path to accept device-resident data; only copy back when fields are written or needed by CPU-only code.
+
+Deliverables:
+- Device residency utilities and lifecycle hooks tied to mesh changes and solver iterations.
+
+Acceptance:
+- Parity holds; observed reduction in transfer time and improved end-to-end speedup.
+
+### Phase 3 — Offload Core fv Operators (targeted set)
+
+Goal: GPU kernels for high-cost operators used by pitzDaily schemes.
+
+Initial operators:
+- `grad(U)`, `div(phi,U)`, `laplacian(nuEff, U)`, interpolation, and simple limiters used in `Gauss linearUpwind`, `upwind`, and `corrected` snGrad.
+
+Core tasks:
+- Implement kernels using mesh addressing; support non-orthogonal corrections.
+- Keep runtime selection: per-operator enable with CPU fallback.
+
+Deliverables:
+- Operator kernels under `src/finiteVolume/...` with device variants; selection flags.
+
+Acceptance:
+- Parity on pitzDaily with GPU operators on; overall speedup ≥2–3× on target GPU.
+
+### Phase 4 — Boundary Conditions & Sources
+
+Goal: GPU implementations for common BCs and source terms.
+
+Targets:
+- Fixed/zero-gradient, inletOutlet, wall functions most used in tutorials.
+- Extend turbulence GPU beyond `nut` if justified (k/epsilon sources).
+
+Acceptance:
+- Parity across broader tutorial set; CPU mode unaffected.
+
+### Phase 5 — Multi‑GPU (MPI)
+
+Goal: Domain-decomposed runs with CUDA‑aware MPI halos.
+
+Core tasks:
+- Device-resident halo exchanges (optional GPUDirect RDMA); overlap comm/compute.
+- Preserve existing decomposition UX.
+
+Acceptance:
+- Parity on decomposed pitzDaily; basic strong scaling validated.
+
+### Phase 6 — Hardening & Docs
+
+Core tasks:
+- CI hooks to build (CPU/GPU), run pitzDaily, compare fields, and track timings.
+- Documentation of runtime flags (fvSolution, momentumTransport) and troubleshooting.
+- Deployment checklist and minimal copy into `/opt/openfoam10` upon approval.
+
+Acceptance:
+- Green CI; reproducible runs; concise docs.
+
+## Risks & Mitigations
+
+- Numerical drift: use DP; avoid FMA changes; unit tests on kernels; parity checks per phase.
+- Transfer overhead: prioritize residency (Phase 2); avoid redundant copies; pin host buffers.
+- Build variability: detect CUDA path; isolate AmgX as optional; keep CPU fallback.
+- External deps: make optional; provide clear build switches and diagnostics.
+
+## Estimates (very rough)
+
+- Phase 1: 1–2 weeks to first GPU solver + 1 week tuning.
+- Phase 2: 1 week.
+- Phase 3: 3–5 weeks (staged).
+- Phase 4: 2–4 weeks.
+- Phase 5: 2–4 weeks.
+- Phase 6: 1 week.
+
+## Decisions
+
+- Backend (Phase 1): Custom CUDA with cuSPARSE/cuSOLVER (PCG/BiCGStab + Jacobi/ILU0) as default path. Keep optional AmgX integration as a future, opt‑in backend.
+- Scope: Single‑GPU for the initial milestones (Phase 1–3). Multi‑GPU arrives in Phase 5.
+- Performance targets (pitzDaily, DP):
+  - Phase 1 (GPU solver only): end‑to‑end speedup ≥1.3×; solver‑only speedup ≥3× for U/p solves.
+  - Phase 2 (resident data): end‑to‑end speedup ≥1.6×.
+  - Phase 3 (fv operators offloaded): end‑to‑end speedup ≥2.0–3.0×.
+
+## Examples
+
+### momentumTransport (GPU turbulence already supported)
+
+```
+simulationType RAS;
+
+RAS
+{
+    model           kEpsilon;
+    turbulence      on;
+    printCoeffs     on;
+
+    kEpsilonCoeffs
+    {
+        device      gpu;      // or: backend gpu, or useGPU true
+        gpuDevice   0;        // or: deviceId 0
+    }
+}
+```
+
+### fvSolution (select GPU solver at runtime; proposal)
+
+```
+// Ensure lib is loaded (in system/controlDict):
+// libs ("libcudaPCG.so");
+
+// Note: cudaPCG (symmetric) is appropriate for pressure. For U/k/epsilon (generally non-symmetric),
+// keep existing smoothSolver or use a future GPU BiCGStab when available.
+
+solvers
+{
+    p
+    {
+        solver          cudaPCG;        // symmetric GPU solver; or amgx
+        tolerance       1e-7;
+        relTol          0.01;
+        preconditioner  diagonal;       // or: ilu0 (if implemented)
+        // amgxConfig  "<path>";       // if AmgX used
+    }
+
+    pFinal { $p; relTol 0; }
+
+    // Keep CPU solvers until a GPU BiCGStab is provided
+    "(U|k|epsilon)"
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-5;
+        relTol          0.1;
+    }
+
+    "(U|k|epsilon)Final" { $U; relTol 0; }
+}
+```
+
+## Implementation Notes
+
+- Keep `FOAM_USE_CUDA` definitions conditional on detected toolchain; fall back cleanly on CPU.
+- Prefer device residency and minimal data marshaling once Phase 2 is in place.
+- Do not alter public headers/interfaces outside additive runtime selection and configuration.
+- Maintain warnings and explicit fallback messages for missing GPU backends.
+
+## Deployment
+
+- Only copy changed, minimal files into `/opt/openfoam10` after all gates pass and with approval. Document exact diffs and paths in deployment notes.
+
+---
+
+Revision: initial draft. Update as phases progress.

--- a/VERIFY.md
+++ b/VERIFY.md
@@ -1,0 +1,127 @@
+# Phase 1 Verification (GPU Linear Solver Offload)
+
+Purpose: Provide a repeatable checklist to validate the Phase 1 work (GPU linear solver offload) in the dev mirror at `home/xiaozhou/OpenFOAM/openfoam10-gpu`, ensuring builds, runs, and comparisons are correct and safe.
+
+## Read First
+- AGENTS.md (repo root)
+- PLAN.md (repo root)
+- Run AGENTS.md: `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/AGENTS.md`
+
+## Preconditions
+- You are on the development machine with CUDA available (for GPU paths).
+- Dev mirror env will be sourced: `. etc/bashrc`.
+- CPU reference case is present and complete at `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_cpu`.
+
+## Verify Structure
+1) Dev mirror exists and is a git repo with required branches
+   - `cd /home/xiaozhou/OpenFOAM/openfoam10-gpu`
+   - `git branch --all` (expect: `main`, `gpu`, and feature branch `feature/gpu-linear-solver`)
+
+2) Scripts exist and are executable
+   - `/home/xiaozhou/OpenFOAM/openfoam10-gpu/tools/build_all.sh`
+   - `/home/xiaozhou/OpenFOAM/openfoam10-gpu/tools/check_gpu_toolchain.sh`
+   - `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/last_time.sh`
+   - `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/compare_latest_U.sh`
+   - `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/run_gpu_trial.sh`
+
+3) Planned solver path (Phase 1)
+   - `src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/` (gated by `FOAM_USE_CUDA`).
+   - Built artifact: `$FOAM_USER_LIBBIN/libcudaPCG.so` after targeted build.
+   - If not present yet, Phase 1 implementation has not been merged; verify CPU fallback steps below.
+
+4) Make/options CUDA flags
+   - Confirm `FOAM_USE_CUDA` and CUDA includes/libs appear where needed (temporary assumption: `/usr/local/cuda`).
+
+## Toolchain Check
+Run the helper to validate CUDA/HIP presence:
+```
+/home/xiaozhou/OpenFOAM/openfoam10-gpu/tools/check_gpu_toolchain.sh
+```
+Expect: detects `nvcc` or `hipcc`. If neither is found, GPU paths must gracefully fall back to CPU.
+
+## Build Checks
+1) Source the dev environment:
+```
+cd /home/xiaozhou/OpenFOAM/openfoam10-gpu
+. etc/bashrc
+```
+2) Keep dev builds green (PVReaders optional):
+```
+export WM_NOCMAKE=on
+```
+3) Full build (logs stored automatically):
+```
+./tools/build_all.sh
+```
+Confirm a new log in `/home/xiaozhou/OpenFOAM/build_logs/build-*.log`.
+
+4) Targeted build (when cudaPCG exists):
+```
+wmake libso src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG
+```
+Confirm the library at `$FOAM_USER_LIBBIN/libcudaPCG.so`.
+If link/ABI issues occur, follow AGENTS.md reset triggers (targeted `wclean`, then `wclean all && ./Allwmake`).
+
+## Run & Compare Checks
+1) Sanity (CPU reference last time):
+```
+/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/last_time.sh \
+  /home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_cpu
+```
+Expect: prints the largest numeric time (e.g., `0.3`).
+
+2) Sanity (self-compare on CPU case):
+```
+/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/compare_latest_U.sh \
+  /home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_cpu \
+  /home/xiaozhou/OpenFOAM/xiaozhou-10/run/pitzDaily_cpu 1e-2
+```
+Expect: succeeds with near-zero relative L2(Ux).
+
+3) GPU trial automation path (dev mirror env):
+```
+/home/xiaozhou/OpenFOAM/xiaozhou-10/run/scripts/run_gpu_trial.sh \
+  pitzDaily_gpu_phase1 \
+  /home/xiaozhou/OpenFOAM/openfoam10-gpu \
+  1e-2
+```
+Expect:
+- Creates/cleans the case, runs to completion, writes logs to `/home/xiaozhou/OpenFOAM/xiaozhou-10/run/logs/pitzDaily_gpu_phase1/`.
+- `compare.txt` exists and reports relative L2; must be ≤ 1e-2 to pass the parity gate.
+
+4) Runtime selection for GPU solver (once implemented)
+- Load the library in `system/controlDict`:
+  - `libs ("libcudaPCG.so");`
+- In the case `system/fvSolution`, set solver names for `(U|k|epsilon|p)` to the GPU variant (planned `cudaPCG`).
+- Rerun step (3). If GPU solver fails to initialize or is unavailable, the run must fall back to CPU solvers without crashing.
+
+## Policies & Safety
+- CPU-as-reference: comparisons always use the last numeric time directory’s `U`.
+- Never write to `/opt/openfoam10` during development; deploy only after all gates pass and with approval.
+- PVReaders can be skipped in dev builds (`WM_NOCMAKE=on`).
+- Keep changes additive; do not commit build artefacts (`platforms/*`, `*/lnInclude/`, `Make/*/*`, logs).
+
+## Report Template
+- Structure
+  - Mirror present: [PASS/FAIL] — path: `/home/xiaozhou/OpenFOAM/openfoam10-gpu`
+  - Branches (`main`, `gpu`, `feature/gpu-linear-solver`): [PASS/FAIL]
+  - Scripts exist/executable (list all five): [PASS/FAIL]
+  - Solver path exists (cudaPCG): [PASS/NA]
+- Toolchain
+  - CUDA/HIP detection output: [text]
+- Build
+  - Build completed (dev) with `WM_NOCMAKE=on`: [PASS/FAIL]
+  - Targeted build `cudaPCG` (if present): [PASS/NA]
+  - Build log saved: [path]
+- Run & Compare
+  - last_time.sh on CPU case: [output]
+  - CPU self-compare: [PASS/FAIL]
+  - GPU trial: [PASS/FAIL], compare log: [path], rel L2(Ux): [value]
+  - GPU runtime selection (if implemented): fallback behavior [OK/FAIL]
+- Policy
+  - Scripts avoid writing to `/opt`: [PASS/FAIL]
+  - Env sourcing uses dev mirror: [PASS/FAIL]
+
+## Notes
+- If CUDA is missing, ensure CPU fallback paths run and the audit still completes with clear warnings.
+- When Phase 1 components are not yet merged, treat solver build/runtime selection checks as N/A; the rest of the pipeline must still be functional.

--- a/applications/solvers/incompressible/pimpleFoamGPU/Make/files
+++ b/applications/solvers/incompressible/pimpleFoamGPU/Make/files
@@ -1,0 +1,3 @@
+pimpleFoamGPU.C
+
+EXE = $(FOAM_USER_APPBIN)/pimpleFoamGPU

--- a/applications/solvers/incompressible/pimpleFoamGPU/Make/options
+++ b/applications/solvers/incompressible/pimpleFoamGPU/Make/options
@@ -1,14 +1,21 @@
 EXE_INC = \
     -I$(FOAM_APP)/solvers/incompressible/pimpleFoam \
+    -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
+    -I$(LIB_SRC)/MomentumTransportModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/physicalProperties/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/turbulenceModels/incompressible/lnInclude \
-    -I$(LIB_SRC)/transportModels \
-    -I$(LIB_SRC)/transportModels/incompressible/lnInclude \
-    -I$(LIB_SRC)/transportModels/interfaceProperties/lnInclude
+    -I$(LIB_SRC)/gpuInfrastructure/lnInclude
 
 EXE_LIBS = \
-    -lincompressibleTransportModels \
-    -lincompressibleTurbulenceModels \
+    -L$(FOAM_USER_LIBBIN) \
+    -lmomentumTransportModels \
+    -lincompressibleMomentumTransportModels \
+    -lphysicalProperties \
     -lfiniteVolume \
-    -lmeshTools
+    -lfvModels \
+    -lfvConstraints \
+    -lsampling \
+    -lmeshTools \
+    -lgpuInfrastructure

--- a/applications/solvers/incompressible/pimpleFoamGPU/Make/options
+++ b/applications/solvers/incompressible/pimpleFoamGPU/Make/options
@@ -1,0 +1,14 @@
+EXE_INC = \
+    -I$(FOAM_APP)/solvers/incompressible/pimpleFoam \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/turbulenceModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/transportModels \
+    -I$(LIB_SRC)/transportModels/incompressible/lnInclude \
+    -I$(LIB_SRC)/transportModels/interfaceProperties/lnInclude
+
+EXE_LIBS = \
+    -lincompressibleTransportModels \
+    -lincompressibleTurbulenceModels \
+    -lfiniteVolume \
+    -lmeshTools

--- a/applications/solvers/incompressible/pimpleFoamGPU/Make/options
+++ b/applications/solvers/incompressible/pimpleFoamGPU/Make/options
@@ -1,4 +1,6 @@
 EXE_INC = \
+    -DFOAM_USE_CUDA \
+    -I/usr/local/cuda/include \
     -I$(FOAM_APP)/solvers/incompressible/pimpleFoam \
     -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
     -I$(LIB_SRC)/MomentumTransportModels/incompressible/lnInclude \
@@ -7,7 +9,8 @@ EXE_INC = \
     -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/gpuInfrastructure/lnInclude \
-    -I$(LIB_SRC)/gpuInfrastructure/FvOperators
+    -I$(LIB_SRC)/gpuInfrastructure/FvOperators \
+    -I$(LIB_SRC)/gpuInfrastructure/KernelCache
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \

--- a/applications/solvers/incompressible/pimpleFoamGPU/Make/options
+++ b/applications/solvers/incompressible/pimpleFoamGPU/Make/options
@@ -6,7 +6,8 @@ EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/gpuInfrastructure/lnInclude
+    -I$(LIB_SRC)/gpuInfrastructure/lnInclude \
+    -I$(LIB_SRC)/gpuInfrastructure/FvOperators
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \

--- a/applications/solvers/incompressible/pimpleFoamGPU/UEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/UEqnGPU.H
@@ -1,0 +1,118 @@
+// Solve the Momentum equation (GPU-aware path)
+
+MRF.correctBoundaryVelocity(U);
+
+bool usedGpuDdt = false;
+Foam::gpu::OperationStats ddtStats;
+word gpuDdtError;
+tmp<fvVectorMatrix> tGpuDdt;
+
+if (useGpuFieldOps && gpuContext.ready())
+{
+    tGpuDdt = Foam::gpu::fvm::ddt
+    (
+        gpuContext,
+        gpuRegistry,
+        U,
+        usedGpuDdt,
+        gpuDdtError,
+        logGpuFieldOps ? &ddtStats : nullptr
+    );
+
+    if (!usedGpuDdt && !gpuDdtError.empty())
+    {
+        WarningInFunction
+            << "GPU fvm::ddt() fallback: " << gpuDdtError << nl << endl;
+    }
+}
+
+tmp<fvVectorMatrix> tDdt;
+if (usedGpuDdt)
+{
+    if (logGpuFieldOps)
+    {
+        gpuOpStats.append
+        (
+            {
+                runTime.timeName(),
+                word("fvmDdt"),
+                ddtStats.gpuMilliseconds
+            }
+        );
+    }
+
+    tDdt = std::move(tGpuDdt);
+}
+else
+{
+    tDdt = fvm::ddt(U);
+}
+
+bool usedGpuDiv = false;
+Foam::gpu::OperationStats divStats;
+word gpuDivError;
+tmp<fvVectorMatrix> tGpuDiv;
+
+if (useGpuFieldOps && gpuContext.ready())
+{
+    tGpuDiv = Foam::gpu::fvm::div
+    (
+        gpuContext,
+        gpuRegistry,
+        phi,
+        U,
+        usedGpuDiv,
+        gpuDivError,
+        logGpuFieldOps ? &divStats : nullptr
+    );
+
+    if (!usedGpuDiv && !gpuDivError.empty())
+    {
+        WarningInFunction
+            << "GPU fvm::div() fallback: " << gpuDivError << nl << endl;
+    }
+}
+
+tmp<fvVectorMatrix> tDiv;
+if (usedGpuDiv)
+{
+    if (logGpuFieldOps)
+    {
+        gpuOpStats.append
+        (
+            {
+                runTime.timeName(),
+                word("fvmDiv"),
+                divStats.gpuMilliseconds
+            }
+        );
+    }
+
+    tDiv = std::move(tGpuDiv);
+}
+else
+{
+    tDiv = fvm::div(phi, U);
+}
+
+tmp<fvVectorMatrix> tUEqn
+(
+    tDdt
+  + tDiv
+  + MRF.DDt(U)
+  + turbulence->divDevSigma(U)
+ == fvModels.source(U)
+);
+
+fvVectorMatrix& UEqn = tUEqn.ref();
+
+UEqn.relax();
+
+fvConstraints.constrain(UEqn);
+
+if (pimple.momentumPredictor())
+{
+    solve(UEqn == -fvc::grad(p));
+
+    fvConstraints.constrain(U);
+}

--- a/applications/solvers/incompressible/pimpleFoamGPU/UEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/UEqnGPU.H
@@ -7,7 +7,7 @@ Foam::gpu::OperationStats ddtStats;
 word gpuDdtError;
 tmp<fvVectorMatrix> tGpuDdt;
 
-if (useGpuFieldOps && gpuContext.ready())
+if (useGpuFieldOps && useGpuDdt && gpuContext.ready())
 {
     tGpuDdt = Foam::gpu::fvm::ddt
     (
@@ -31,6 +31,42 @@ if (usedGpuDdt)
 {
     if (logGpuFieldOps)
     {
+        tmp<fvVectorMatrix> tDdtCpuCheck = fvm::ddt(U);
+        fvVectorMatrix& ddtGpu = tGpuDdt.ref();
+        const fvVectorMatrix& ddtCpu = tDdtCpuCheck();
+
+        const scalarField& diagGpu = ddtGpu.diag();
+        const scalarField& diagCpu = ddtCpu.diag();
+        const scalarField& cellVolumes = U.mesh().V();
+        scalar diagDiffSq = 0.0;
+        scalar diagRefSq = 0.0;
+        forAll(diagGpu, celli)
+        {
+            const scalar diff = diagGpu[celli] - diagCpu[celli];
+            const scalar w = cellVolumes[celli];
+            diagDiffSq += w*diff*diff;
+            diagRefSq += w*diagCpu[celli]*diagCpu[celli];
+        }
+        diagRefSq = max(diagRefSq, VSMALL);
+
+        const vectorField& sourceGpu = ddtGpu.source();
+        const vectorField& sourceCpu = ddtCpu.source();
+        scalar sourceDiffSq = 0.0;
+        scalar sourceRefSq = 0.0;
+        forAll(sourceGpu, celli)
+        {
+            const vector diff = sourceGpu[celli] - sourceCpu[celli];
+            const scalar w = cellVolumes[celli];
+            sourceDiffSq += w*(diff & diff);
+            sourceRefSq += w*(sourceCpu[celli] & sourceCpu[celli]);
+        }
+        sourceRefSq = max(sourceRefSq, VSMALL);
+
+        Info<< "GPU fvm::ddt relative mismatches: diag="
+            << Foam::sqrt(diagDiffSq/diagRefSq)
+            << ", source=" << Foam::sqrt(sourceDiffSq/sourceRefSq)
+            << nl;
+
         gpuOpStats.append
         (
             {
@@ -53,7 +89,7 @@ Foam::gpu::OperationStats divStats;
 word gpuDivError;
 tmp<fvVectorMatrix> tGpuDiv;
 
-if (useGpuFieldOps && gpuContext.ready())
+if (useGpuFieldOps && useGpuDiv && gpuContext.ready())
 {
     tGpuDiv = Foam::gpu::fvm::div
     (
@@ -78,6 +114,71 @@ if (usedGpuDiv)
 {
     if (logGpuFieldOps)
     {
+        tmp<fvVectorMatrix> tDivCpuCheck = fvm::div(phi, U);
+        fvVectorMatrix& divGpu = tGpuDiv.ref();
+        const fvVectorMatrix& divCpu = tDivCpuCheck();
+
+        tmp<fvVectorMatrix> tDivGpuInspect = divGpu.clone();
+        const fvVectorMatrix& divGpuInspect = tDivGpuInspect();
+
+        const scalarField& diagGpu = divGpuInspect.diag();
+        const scalarField& diagCpu = divCpu.diag();
+        const scalarField& cellVolumes = U.mesh().V();
+        scalar diagDiffSq = 0.0;
+        scalar diagRefSq = 0.0;
+        forAll(diagGpu, celli)
+        {
+            const scalar diff = diagGpu[celli] - diagCpu[celli];
+            const scalar w = cellVolumes[celli];
+            diagDiffSq += w*diff*diff;
+            diagRefSq += w*diagCpu[celli]*diagCpu[celli];
+        }
+        diagRefSq = max(diagRefSq, VSMALL);
+
+        const scalarField& lowerGpu = divGpuInspect.lower();
+        const scalarField& lowerCpu = divCpu.lower();
+        scalar lowerDiffSq = 0.0;
+        scalar lowerRefSq = 0.0;
+        forAll(lowerGpu, facei)
+        {
+            const scalar diff = lowerGpu[facei] - lowerCpu[facei];
+            lowerDiffSq += diff*diff;
+            lowerRefSq += lowerCpu[facei]*lowerCpu[facei];
+        }
+        lowerRefSq = max(lowerRefSq, VSMALL);
+
+        const scalarField& upperGpu = divGpuInspect.upper();
+        const scalarField& upperCpu = divCpu.upper();
+        scalar upperDiffSq = 0.0;
+        scalar upperRefSq = 0.0;
+        forAll(upperGpu, facei)
+        {
+            const scalar diff = upperGpu[facei] - upperCpu[facei];
+            upperDiffSq += diff*diff;
+            upperRefSq += upperCpu[facei]*upperCpu[facei];
+        }
+        upperRefSq = max(upperRefSq, VSMALL);
+
+        const vectorField& sourceGpu = divGpuInspect.source();
+        const vectorField& sourceCpu = divCpu.source();
+        scalar sourceDiffSq = 0.0;
+        scalar sourceRefSq = 0.0;
+        forAll(sourceGpu, celli)
+        {
+            const vector diff = sourceGpu[celli] - sourceCpu[celli];
+            const scalar w = cellVolumes[celli];
+            sourceDiffSq += w*(diff & diff);
+            sourceRefSq += w*(sourceCpu[celli] & sourceCpu[celli]);
+        }
+        sourceRefSq = max(sourceRefSq, VSMALL);
+
+        Info<< "GPU fvm::div relative mismatches: diag="
+            << Foam::sqrt(diagDiffSq/diagRefSq)
+            << ", lower=" << Foam::sqrt(lowerDiffSq/lowerRefSq)
+            << ", upper=" << Foam::sqrt(upperDiffSq/upperRefSq)
+            << ", source=" << Foam::sqrt(sourceDiffSq/sourceRefSq)
+            << nl;
+
         gpuOpStats.append
         (
             {
@@ -105,6 +206,111 @@ tmp<fvVectorMatrix> tUEqn
 );
 
 fvVectorMatrix& UEqn = tUEqn.ref();
+
+if (logGpuFieldOps)
+{
+    tmp<fvVectorMatrix> tUEqnCpuCheck
+    (
+        fvm::ddt(U)
+      + fvm::div(phi, U)
+      + MRF.DDt(U)
+      + turbulence->divDevSigma(U)
+     == fvModels.source(U)
+    );
+
+    tmp<fvVectorMatrix> tUEqnGpuInspect = UEqn.clone();
+
+    const fvVectorMatrix& UEqnGpuInspect = tUEqnGpuInspect();
+    const fvVectorMatrix& UEqnCpu = tUEqnCpuCheck();
+
+    const scalarField& cellVolumes = U.mesh().V();
+
+    const scalarField& diagGpu = UEqnGpuInspect.diag();
+    const scalarField& diagCpu = UEqnCpu.diag();
+    scalar diagDiffSq = 0.0;
+    scalar diagRefSq = 0.0;
+    forAll(diagGpu, celli)
+    {
+        const scalar diff = diagGpu[celli] - diagCpu[celli];
+        const scalar w = cellVolumes[celli];
+        diagDiffSq += w*diff*diff;
+        diagRefSq += w*diagCpu[celli]*diagCpu[celli];
+    }
+    diagRefSq = max(diagRefSq, VSMALL);
+
+    const scalarField& lowerGpu = UEqnGpuInspect.lower();
+    const scalarField& lowerCpu = UEqnCpu.lower();
+    scalar lowerDiffSq = 0.0;
+    scalar lowerRefSq = 0.0;
+    forAll(lowerGpu, facei)
+    {
+        const scalar diff = lowerGpu[facei] - lowerCpu[facei];
+        lowerDiffSq += diff*diff;
+        lowerRefSq += lowerCpu[facei]*lowerCpu[facei];
+    }
+    lowerRefSq = max(lowerRefSq, VSMALL);
+
+    const scalarField& upperGpu = UEqnGpuInspect.upper();
+    const scalarField& upperCpu = UEqnCpu.upper();
+    scalar upperDiffSq = 0.0;
+    scalar upperRefSq = 0.0;
+    forAll(upperGpu, facei)
+    {
+        const scalar diff = upperGpu[facei] - upperCpu[facei];
+        upperDiffSq += diff*diff;
+        upperRefSq += upperCpu[facei]*upperCpu[facei];
+    }
+    upperRefSq = max(upperRefSq, VSMALL);
+
+    const vectorField& sourceGpu = UEqnGpuInspect.source();
+    const vectorField& sourceCpu = UEqnCpu.source();
+    scalar sourceDiffSq = 0.0;
+    scalar sourceRefSq = 0.0;
+    scalar maxSourceDiff = 0.0;
+    label maxSourceDiffCell = -1;
+    vector maxSourceDiffVec = Zero;
+    forAll(sourceGpu, celli)
+    {
+        const vector diff = sourceGpu[celli] - sourceCpu[celli];
+        const scalar w = cellVolumes[celli];
+        sourceDiffSq += w*(diff & diff);
+        sourceRefSq += w*(sourceCpu[celli] & sourceCpu[celli]);
+        const scalar magDiff = Foam::sqrt(diff & diff);
+        if (magDiff > maxSourceDiff)
+        {
+            maxSourceDiff = magDiff;
+            maxSourceDiffCell = celli;
+            maxSourceDiffVec = diff;
+        }
+    }
+    sourceRefSq = max(sourceRefSq, VSMALL);
+
+        Info<< "GPU UEqn matrix mismatches: diag="
+            << Foam::sqrt(diagDiffSq/diagRefSq)
+            << ", lower=" << Foam::sqrt(lowerDiffSq/lowerRefSq)
+            << ", upper=" << Foam::sqrt(upperDiffSq/upperRefSq)
+            << ", source=" << Foam::sqrt(sourceDiffSq/sourceRefSq)
+            << " (absMaxSourceDiff=" << maxSourceDiff;
+    if (maxSourceDiffCell >= 0)
+    {
+        const vector expectedSource =
+            UEqnGpuInspect.diag()[maxSourceDiffCell]
+           *U.oldTime().internalField()[maxSourceDiffCell];
+        Info<< " @cell " << maxSourceDiffCell
+            << ", diff=" << maxSourceDiffVec
+            << ", gpu=" << sourceGpu[maxSourceDiffCell]
+            << ", cpu=" << sourceCpu[maxSourceDiffCell]
+            << ", U_old=" << U.oldTime().internalField()[maxSourceDiffCell]
+            << ", U_new=" << U.internalField()[maxSourceDiffCell]
+            << ", V=" << U.mesh().V()[maxSourceDiffCell]
+            << ", diag=" << UEqnGpuInspect.diag()[maxSourceDiffCell]
+            << ", expected=" << expectedSource;
+    }
+    Info<< ')' << nl;
+
+    tUEqnGpuInspect.clear();
+    tUEqnCpuCheck.clear();
+}
 
 UEqn.relax();
 

--- a/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
@@ -42,6 +42,8 @@ while (pimple.correctNonOrthogonal())
     Foam::gpu::OperationStats lapStats;
     word gpuLapError;
     tmp<fvScalarMatrix> tGpuLap;
+    bool forcePressureOverwrite = false;
+    tmp<surfaceScalarField> forcedPhiTmp;
 
     if (useGpuFieldOps && gpuContext.ready())
     {
@@ -69,6 +71,60 @@ while (pimple.correctNonOrthogonal())
     {
         if (logGpuFieldOps)
         {
+            tmp<fvScalarMatrix> tLapCpuCheck = fvm::laplacian(rAtUField, p);
+            fvScalarMatrix& lapGpu = tGpuLap.ref();
+            const fvScalarMatrix& lapCpu = tLapCpuCheck();
+            const bool lapAsymmetricBefore = lapGpu.asymmetric();
+
+            tmp<fvScalarMatrix> tLapGpuInspect = lapGpu.clone();
+            const fvScalarMatrix& lapGpuInspect = tLapGpuInspect();
+
+            const scalarField& diagGpu = lapGpuInspect.diag();
+            const scalarField& diagCpu = lapCpu.diag();
+            const scalarField& cellVolumes = p.mesh().V();
+            scalar diagDiffSq = 0.0;
+            scalar diagRefSq = 0.0;
+            forAll(diagGpu, celli)
+            {
+                const scalar diff = diagGpu[celli] - diagCpu[celli];
+                const scalar w = cellVolumes[celli];
+                diagDiffSq += w*diff*diff;
+                diagRefSq += w*diagCpu[celli]*diagCpu[celli];
+            }
+            diagRefSq = max(diagRefSq, VSMALL);
+
+            const scalarField& upperGpu = lapGpuInspect.upper();
+            const scalarField& upperCpu = lapCpu.upper();
+            scalar upperDiffSq = 0.0;
+            scalar upperRefSq = 0.0;
+            forAll(upperGpu, facei)
+            {
+                const scalar diff = upperGpu[facei] - upperCpu[facei];
+                upperDiffSq += diff*diff;
+                upperRefSq += upperCpu[facei]*upperCpu[facei];
+            }
+            upperRefSq = max(upperRefSq, VSMALL);
+
+            const scalarField& sourceGpu = lapGpuInspect.source();
+            const scalarField& sourceCpu = lapCpu.source();
+            scalar sourceDiffSq = 0.0;
+            scalar sourceRefSq = 0.0;
+            forAll(sourceGpu, celli)
+            {
+                const scalar diff = sourceGpu[celli] - sourceCpu[celli];
+                const scalar w = cellVolumes[celli];
+                sourceDiffSq += w*diff*diff;
+                sourceRefSq += w*sourceCpu[celli]*sourceCpu[celli];
+            }
+            sourceRefSq = max(sourceRefSq, VSMALL);
+
+            Info<< "GPU fvm::laplacian relative mismatches: diag="
+                << Foam::sqrt(diagDiffSq/diagRefSq)
+                << ", upper=" << Foam::sqrt(upperDiffSq/upperRefSq)
+                << ", source=" << Foam::sqrt(sourceDiffSq/sourceRefSq)
+                << ", asymmetric(before)=" << (lapAsymmetricBefore ? "yes" : "no")
+                << nl;
+
             gpuOpStats.append
             (
                 {
@@ -86,19 +142,313 @@ while (pimple.correctNonOrthogonal())
         tLap = fvm::laplacian(rAtUField, p);
     }
 
+    tmp<volScalarField> tDivPhiHbyA(fvc::div(phiHbyA));
+    const volScalarField& divPhiHbyA = tDivPhiHbyA();
+
     fvScalarMatrix pEqn
     (
         tLap
-     == fvc::div(phiHbyA)
+     == divPhiHbyA
     );
 
-    pEqn.setReference
-    (
-        pressureReference.refCell(),
-        pressureReference.refValue()
-    );
+    scalarField pSourcePreReference;
+    if (logGpuFieldOps)
+    {
+        pSourcePreReference = pEqn.source();
+    }
 
-    pEqn.solve();
+    const label refCell = pressureReference.refCell();
+    const scalar refValue = pressureReference.refValue();
+
+    if (logGpuFieldOps)
+    {
+        Info<< "pressureReference: cell=" << refCell
+            << ", value=" << refValue << nl;
+        Info<< "div(phiHbyA) stats: min="
+            << gMin(divPhiHbyA.internalField())
+            << ", max=" << gMax(divPhiHbyA.internalField())
+            << ", mean=" << gAverage(divPhiHbyA.internalField()) << nl;
+    }
+
+    pEqn.setReference(refCell, refValue);
+
+    if (logGpuFieldOps)
+    {
+        const scalarField& sourcePostReference = pEqn.source();
+        Info<< "GPU pressure source preRef stats: min="
+            << gMin(pSourcePreReference)
+            << ", max=" << gMax(pSourcePreReference)
+            << ", mean=" << gAverage(pSourcePreReference)
+            << ", magMax=" << gMax(mag(pSourcePreReference)) << nl;
+        Info<< "GPU pressure source postRef stats: min="
+            << gMin(sourcePostReference)
+            << ", max=" << gMax(sourcePostReference)
+            << ", mean=" << gAverage(sourcePostReference)
+            << ", magMax=" << gMax(mag(sourcePostReference)) << nl;
+    }
+
+    const fvMesh& pMesh = p.mesh();
+    const bool finalIteration =
+        !pMesh.schemes().steady()
+     && pMesh.data::lookupOrDefault<bool>("finalIteration", false);
+
+    const dictionary& baseSolverControls =
+        pMesh.solution().solverDict(p.select(finalIteration));
+
+    if (useGpuFieldOps && gpuContext.ready())
+    {
+        word solverType;
+        if
+        (
+            baseSolverControls.readIfPresent("solver", solverType)
+         && solverType == "GAMG"
+        )
+        {
+            dictionary solverControls(baseSolverControls);
+            solverControls.set("cacheAgglomeration", false);
+
+            if (logGpuFieldOps)
+            {
+                Info<< "GPU pressure solve disabling GAMG cacheAgglomeration"
+                    << nl;
+            }
+
+            pEqn.solve(solverControls);
+        }
+        else
+        {
+            pEqn.solve(baseSolverControls);
+        }
+    }
+    else
+    {
+        pEqn.solve(baseSolverControls);
+    }
+
+    const bool needCpuShadowSolve =
+        static_cast<bool>(logGpuFieldOps) || static_cast<bool>(forceCpuPressureCorrector);
+
+    if (needCpuShadowSolve)
+    {
+        if (logGpuFieldOps)
+        {
+            const scalarField& pField = p.internalField();
+            Info<< "GPU pressure field pre-shadow stats: min="
+                << gMin(pField)
+                << ", max=" << gMax(pField)
+                << ", mean=" << gAverage(pField)
+                << ", magMax=" << gMax(mag(pField)) << nl;
+        }
+
+        volScalarField pCpuCheck
+        (
+            IOobject
+            (
+                "p_cpuCheck",
+                runTime.timeName(),
+                p.mesh(),
+                IOobject::NO_READ,
+                IOobject::NO_WRITE,
+                false
+            ),
+            p
+        );
+
+        pCpuCheck.rename(p.name());
+
+        const scalarField& cellVolumes = p.mesh().V();
+
+        tmp<fvScalarMatrix> tCpuEqn
+        (
+            fvm::laplacian(rAtUField, pCpuCheck)
+         == divPhiHbyA
+        );
+        fvScalarMatrix& cpuEqn = tCpuEqn.ref();
+
+        scalarField cpuSourcePreReference;
+        if (logGpuFieldOps)
+        {
+            cpuSourcePreReference = cpuEqn.source();
+        }
+
+        cpuEqn.setReference(refCell, refValue);
+
+        if (logGpuFieldOps)
+        {
+            const scalarField& cpuSourcePostReference = cpuEqn.source();
+            Info<< "CPU shadow pressure source preRef stats: min="
+                << gMin(cpuSourcePreReference)
+                << ", max=" << gMax(cpuSourcePreReference)
+                << ", mean=" << gAverage(cpuSourcePreReference)
+                << ", magMax=" << gMax(mag(cpuSourcePreReference)) << nl;
+            Info<< "CPU shadow pressure source postRef stats: min="
+                << gMin(cpuSourcePostReference)
+                << ", max=" << gMax(cpuSourcePostReference)
+                << ", mean=" << gAverage(cpuSourcePostReference)
+                << ", magMax=" << gMax(mag(cpuSourcePostReference)) << nl;
+
+            scalar srcPreDiffSq = 0.0;
+            scalar srcPreRefSq = 0.0;
+            scalar maxSrcPreDiff = 0.0;
+            forAll(pSourcePreReference, celli)
+            {
+                const scalar diff =
+                    pSourcePreReference[celli] - cpuSourcePreReference[celli];
+                const scalar w = cellVolumes[celli];
+                srcPreDiffSq += w*diff*diff;
+                srcPreRefSq += w*cpuSourcePreReference[celli]
+                    *cpuSourcePreReference[celli];
+                maxSrcPreDiff = max(maxSrcPreDiff, mag(diff));
+            }
+            srcPreRefSq = max(srcPreRefSq, VSMALL);
+
+            Info<< "GPU pressure source preSolve relative mismatch: "
+                << Foam::sqrt(srcPreDiffSq/srcPreRefSq)
+                << " (absMaxDiff=" << maxSrcPreDiff << ')' << nl;
+        }
+
+        if (logGpuFieldOps)
+        {
+            const scalarField& gpuDiag = pEqn.diag();
+            const scalarField& gpuUpper = pEqn.upper();
+            const scalarField& gpuSource = pEqn.source();
+            const scalarField& cpuDiag = cpuEqn.diag();
+            const scalarField& cpuUpper = cpuEqn.upper();
+            const scalarField& cpuSource = cpuEqn.source();
+            const scalarField& cellVolumes = p.mesh().V();
+
+            scalar diagDiffSq = 0.0;
+            scalar diagRefSq = 0.0;
+            forAll(gpuDiag, celli)
+            {
+                const scalar diff = gpuDiag[celli] - cpuDiag[celli];
+                const scalar w = cellVolumes[celli];
+                diagDiffSq += w*diff*diff;
+                diagRefSq += w*cpuDiag[celli]*cpuDiag[celli];
+            }
+            diagRefSq = max(diagRefSq, VSMALL);
+
+            scalar upperDiffSq = 0.0;
+            scalar upperRefSq = 0.0;
+            forAll(gpuUpper, facei)
+            {
+                const scalar diff = gpuUpper[facei] - cpuUpper[facei];
+                upperDiffSq += diff*diff;
+                upperRefSq += cpuUpper[facei]*cpuUpper[facei];
+            }
+            upperRefSq = max(upperRefSq, VSMALL);
+
+            scalar srcDiffSq = 0.0;
+            scalar srcRefSq = 0.0;
+            scalar maxSrcDiff = 0.0;
+            label maxSrcCell = -1;
+            forAll(gpuSource, celli)
+            {
+                const scalar diff = gpuSource[celli] - cpuSource[celli];
+                const scalar w = cellVolumes[celli];
+                srcDiffSq += w*diff*diff;
+                srcRefSq += w*cpuSource[celli]*cpuSource[celli];
+                if (mag(diff) > maxSrcDiff)
+                {
+                    maxSrcDiff = mag(diff);
+                    maxSrcCell = celli;
+                }
+            }
+            srcRefSq = max(srcRefSq, VSMALL);
+
+            Info<< "GPU pressure matrix mismatches: diag="
+                << Foam::sqrt(diagDiffSq/diagRefSq)
+                << ", upper=" << Foam::sqrt(upperDiffSq/upperRefSq)
+                << ", source=" << Foam::sqrt(srcDiffSq/srcRefSq)
+                << " (maxDiff=" << maxSrcDiff << " @cell " << maxSrcCell;
+            if (maxSrcCell >= 0)
+            {
+                Info<< ", srcGpu=" << gpuSource[maxSrcCell]
+                    << ", srcCpu=" << cpuSource[maxSrcCell]
+                    << ", divPhiHbyA=" << divPhiHbyA.internalField()[maxSrcCell]
+                    << ", rAtU=" << rAtUField.internalField()[maxSrcCell]
+                    << ", V=" << p.mesh().V()[maxSrcCell];
+            }
+            Info<< ')' << nl;
+        }
+
+        dictionary cpuSolverControls(baseSolverControls);
+        cpuSolverControls.set("cacheAgglomeration", false);
+        cpuEqn.solve(cpuSolverControls);
+
+        if (logGpuFieldOps)
+        {
+            const scalarField& pGpuField = p.internalField();
+            const scalarField& pCpuField = pCpuCheck.internalField();
+
+            scalar diffSq = 0.0;
+            scalar refSq = 0.0;
+            forAll(pGpuField, celli)
+            {
+                const scalar diff = pGpuField[celli] - pCpuField[celli];
+                const scalar w = cellVolumes[celli];
+                diffSq += w*diff*diff;
+                refSq += w*pCpuField[celli]*pCpuField[celli];
+            }
+            refSq = max(refSq, VSMALL);
+
+            Info<< "GPU pressure solve relative mismatch: "
+                << Foam::sqrt(diffSq/refSq) << nl;
+
+            const scalarField& gpuSrc = pEqn.source();
+            const scalarField& cpuSrc = cpuEqn.source();
+            scalar srcDiffSq = 0.0;
+            scalar srcRefSq = 0.0;
+            scalar maxSrcDiff = 0.0;
+            forAll(gpuSrc, celli)
+            {
+                const scalar diff = gpuSrc[celli] - cpuSrc[celli];
+                const scalar w = cellVolumes[celli];
+                srcDiffSq += w*diff*diff;
+                srcRefSq += w*cpuSrc[celli]*cpuSrc[celli];
+                maxSrcDiff = max(maxSrcDiff, mag(diff));
+            }
+            srcRefSq = max(srcRefSq, VSMALL);
+            Info<< "GPU pressure source postSolve relative mismatch: "
+                << Foam::sqrt(srcDiffSq/srcRefSq)
+                << " (absMaxDiff=" << maxSrcDiff << ')' << nl;
+        }
+
+        if (forceCpuPressureCorrector)
+        {
+            p = pCpuCheck;
+            gpuRegistry.getOrCreate(p).markHostDirty();
+
+            forcedPhiTmp = phiHbyA - cpuEqn.flux();
+            forcePressureOverwrite = true;
+
+            if (logGpuFieldOps)
+            {
+                const scalar cpuMin = gMin(pCpuCheck.internalField());
+                const scalar cpuMax = gMax(pCpuCheck.internalField());
+                const scalar gpuMin = gMin(p.internalField());
+                const scalar gpuMax = gMax(p.internalField());
+                Info<< "GPU pressure solve forced to CPU shadow result"
+                    << " (cpu min=" << cpuMin
+                    << ", cpu max=" << cpuMax
+                    << ", p min=" << gpuMin
+                    << ", p max=" << gpuMax << ')'
+                    << nl;
+            }
+        }
+
+        if (logGpuFieldOps)
+        {
+            const scalarField& pShadowField = pCpuCheck.internalField();
+            Info<< "CPU shadow pressure stats: min="
+                << gMin(pShadowField)
+                << ", max=" << gMax(pShadowField)
+                << ", mean=" << gAverage(pShadowField)
+                << ", magMax=" << gMax(mag(pShadowField)) << nl;
+        }
+    }
+
+    tDivPhiHbyA.clear();
 
     if (pimple.finalNonOrthogonalIter())
     {
@@ -108,7 +458,18 @@ while (pimple.correctNonOrthogonal())
         Foam::gpu::DeviceField<surfaceScalarField>& phiDev =
             gpuRegistry.getOrCreate(phi);
 
-        if (useGpuFieldOps && gpuContext.ready())
+        if (forcePressureOverwrite && forceCpuPressureCorrector)
+        {
+            phi = forcedPhiTmp;
+            phiDev.markHostDirty();
+            gpuUpdatedPhi = true;
+
+            if (logGpuFieldOps)
+            {
+                Info<< "GPU phiCorrector forced to CPU shadow result" << nl;
+            }
+        }
+        else if (useGpuFieldOps && gpuContext.ready())
         {
             word gpuError;
             Foam::gpu::OperationStats phiStats;
@@ -145,8 +506,45 @@ while (pimple.correctNonOrthogonal())
             if (ok)
             {
                 gpuUpdatedPhi = true;
+                surfaceScalarField::Boundary& phiBf = phi.boundaryFieldRef();
+                const surfaceScalarField::Boundary& phiHbyABf =
+                    phiHbyA.boundaryField();
+                const surfaceScalarField::Boundary& phiFluxBf =
+                    phiFlux.boundaryField();
+
+                forAll(phiBf, patchi)
+                {
+                    phiBf[patchi] ==
+                        phiHbyABf[patchi] - phiFluxBf[patchi];
+                }
+
+                phiDev.markHostDirty();
+
                 if (logGpuFieldOps)
                 {
+                    const scalarField& phiGpuInternal = phi.internalField();
+                    const scalarField& phiHbyAInternal =
+                        phiHbyA.internalField();
+                    const scalarField& phiFluxInternal =
+                        phiFlux.internalField();
+                    const scalarField& faceAreas = phi.mesh().magSf();
+
+                    scalar diffSq = 0.0;
+                    scalar refSq = 0.0;
+                    forAll(phiGpuInternal, facei)
+                    {
+                        const scalar cpuVal =
+                            phiHbyAInternal[facei] - phiFluxInternal[facei];
+                        const scalar diff = phiGpuInternal[facei] - cpuVal;
+                        const scalar w = faceAreas[facei];
+                        diffSq += w*diff*diff;
+                        refSq += w*cpuVal*cpuVal;
+                    }
+                    refSq = max(refSq, VSMALL);
+
+                    Info<< "GPU phiCorrector relative mismatches: internal="
+                        << Foam::sqrt(diffSq/refSq) << nl;
+
                     gpuOpStats.append
                     (
                         {
@@ -238,6 +636,34 @@ if (useGpuFieldOps && gpuContext.ready())
         gpuUpdatedU = true;
         if (logGpuFieldOps)
         {
+            volVectorField cpuVelocityCheck
+            (
+                IOobject
+                (
+                    "U_cpuCheck",
+                    runTime.timeName(),
+                    U.mesh(),
+                    IOobject::NO_READ,
+                    IOobject::NO_WRITE
+                ),
+                HbyA - rAtUField*gradP
+            );
+            const scalarField& volumes = U.mesh().V();
+            const vectorField& uGpu = U.internalField();
+            const vectorField& uCpu = cpuVelocityCheck.internalField();
+            scalar diffSq = 0.0;
+            scalar refSq = 0.0;
+            forAll(uGpu, celli)
+            {
+                const vector delta = uGpu[celli] - uCpu[celli];
+                diffSq += volumes[celli]*(delta & delta);
+                refSq += volumes[celli]*(uCpu[celli] & uCpu[celli]);
+            }
+            refSq = max(refSq, VSMALL);
+            const scalar relErr = Foam::sqrt(diffSq/refSq);
+            Info<< "GPU velocityCorrector relative L2 mismatch: "
+                << relErr << nl;
+
             gpuOpStats.append
             (
                 {

--- a/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
@@ -56,25 +56,31 @@ while (pimple.correctNonOrthogonal())
         surfaceScalarField phiFlux(pEqn.flux());
 
         bool gpuUpdatedPhi = false;
-        Foam::gpu::DeviceField<surfaceScalarField>* phiDevPtr = nullptr;
+        Foam::gpu::DeviceField<surfaceScalarField>& phiDev =
+            gpuRegistry.getOrCreate(phi);
 
         if (useGpuFieldOps && gpuContext.ready())
         {
             word gpuError;
             Foam::gpu::OperationStats phiStats;
 
-            phiDevPtr = &gpuRegistry.getOrCreate(phi);
-            Foam::gpu::DeviceField<surfaceScalarField> phiHbyADev(phiHbyA);
-            Foam::gpu::DeviceField<surfaceScalarField> fluxDev(phiFlux);
+            Foam::gpu::DeviceField<surfaceScalarField>& phiHbyADev =
+                gpuRegistry.getOrCreate(phiHbyA);
+            Foam::gpu::DeviceField<surfaceScalarField>& fluxDev =
+                gpuRegistry.getOrCreate(phiFlux);
+
+            phiDev.markHostDirty();
+            phiHbyADev.markHostDirty();
+            fluxDev.markHostDirty();
 
             bool ok =
-                phiDevPtr->syncHostToDevice(gpuContext, gpuError)
+                phiDev.syncHostToDevice(gpuContext, gpuError)
              && phiHbyADev.syncHostToDevice(gpuContext, gpuError)
              && fluxDev.syncHostToDevice(gpuContext, gpuError)
              && subtractSurfaceScalarFields
                 (
                     gpuContext,
-                    *phiDevPtr,
+                    phiDev,
                     phiHbyADev,
                     fluxDev,
                     gpuError,
@@ -83,8 +89,8 @@ while (pimple.correctNonOrthogonal())
 
             if (ok)
             {
-                phiDevPtr->markDeviceDirty();
-                ok = phiDevPtr->syncDeviceToHost(gpuContext, gpuError);
+                phiDev.markDeviceDirty();
+                ok = phiDev.syncDeviceToHost(gpuContext, gpuError);
             }
 
             if (ok)
@@ -92,8 +98,14 @@ while (pimple.correctNonOrthogonal())
                 gpuUpdatedPhi = true;
                 if (logGpuFieldOps)
                 {
-                    Info<< "cuda phi update: " << phiStats.gpuMilliseconds
-                        << " ms" << nl;
+                    gpuOpStats.append
+                    (
+                        {
+                            runTime.timeName(),
+                            word("phiCorrector"),
+                            phiStats.gpuMilliseconds
+                        }
+                    );
                 }
             }
             else if (!gpuError.empty())
@@ -106,10 +118,17 @@ while (pimple.correctNonOrthogonal())
         if (!gpuUpdatedPhi)
         {
             phi = phiHbyA - phiFlux;
-
-            if (phiDevPtr)
+            phiDev.markHostDirty();
+            if (logGpuFieldOps)
             {
-                phiDevPtr->markHostDirty();
+                gpuOpStats.append
+                (
+                    {
+                        runTime.timeName(),
+                        word("phiCorrector_cpu"),
+                        Foam::scalar(-1)
+                    }
+                );
             }
         }
     }
@@ -124,27 +143,34 @@ tmp<volVectorField> gradPTmp(fvc::grad(p));
 volVectorField& gradP = gradPTmp.ref();
 
 bool gpuUpdatedU = false;
-Foam::gpu::DeviceField<volVectorField>* uDevPtr = nullptr;
+Foam::gpu::DeviceField<volVectorField>& uDev = gpuRegistry.getOrCreate(U);
 
 if (useGpuFieldOps && gpuContext.ready())
 {
     word gpuError;
     Foam::gpu::OperationStats uStats;
 
-    uDevPtr = &gpuRegistry.getOrCreate(U);
-    Foam::gpu::DeviceField<volVectorField> hbyADev(HbyA);
-    Foam::gpu::DeviceField<volScalarField> rAtUDev(rAtUField);
-    Foam::gpu::DeviceField<volVectorField> gradPDev(gradP);
+    Foam::gpu::DeviceField<volVectorField>& hbyADev =
+        gpuRegistry.getOrCreate(HbyA);
+    Foam::gpu::DeviceField<volScalarField>& rAtUDev =
+        gpuRegistry.getOrCreate(rAtUField);
+    Foam::gpu::DeviceField<volVectorField>& gradPDev =
+        gpuRegistry.getOrCreate(gradP);
+
+    uDev.markHostDirty();
+    hbyADev.markHostDirty();
+    rAtUDev.markHostDirty();
+    gradPDev.markHostDirty();
 
     bool ok =
-        uDevPtr->syncHostToDevice(gpuContext, gpuError)
+        uDev.syncHostToDevice(gpuContext, gpuError)
      && hbyADev.syncHostToDevice(gpuContext, gpuError)
      && rAtUDev.syncHostToDevice(gpuContext, gpuError)
      && gradPDev.syncHostToDevice(gpuContext, gpuError)
      && velocityCorrector
         (
             gpuContext,
-            *uDevPtr,
+            uDev,
             hbyADev,
             rAtUDev,
             gradPDev,
@@ -154,8 +180,8 @@ if (useGpuFieldOps && gpuContext.ready())
 
     if (ok)
     {
-        uDevPtr->markDeviceDirty();
-        ok = uDevPtr->syncDeviceToHost(gpuContext, gpuError);
+        uDev.markDeviceDirty();
+        ok = uDev.syncDeviceToHost(gpuContext, gpuError);
     }
 
     if (ok)
@@ -163,7 +189,14 @@ if (useGpuFieldOps && gpuContext.ready())
         gpuUpdatedU = true;
         if (logGpuFieldOps)
         {
-            Info<< "cuda U update: " << uStats.gpuMilliseconds << " ms" << nl;
+            gpuOpStats.append
+            (
+                {
+                    runTime.timeName(),
+                    word("velocityCorrector"),
+                    uStats.gpuMilliseconds
+                }
+            );
         }
     }
     else if (!gpuError.empty())
@@ -176,10 +209,17 @@ if (useGpuFieldOps && gpuContext.ready())
 if (!gpuUpdatedU)
 {
     U = HbyA - rAtUField*gradP;
-
-    if (uDevPtr)
+    uDev.markHostDirty();
+    if (logGpuFieldOps)
     {
-        uDevPtr->markHostDirty();
+        gpuOpStats.append
+        (
+            {
+                runTime.timeName(),
+                    word("velocityCorrector_cpu"),
+                    Foam::scalar(-1)
+            }
+        );
     }
 }
 

--- a/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
@@ -1,0 +1,195 @@
+volScalarField rAU(1.0/UEqn.A());
+volVectorField HbyA(constrainHbyA(rAU*UEqn.H(), U, p));
+surfaceScalarField phiHbyA
+(
+    "phiHbyA",
+    fvc::flux(HbyA)
+  + MRF.zeroFilter(fvc::interpolate(rAU)*fvc::ddtCorr(U, phi, Uf))
+);
+
+MRF.makeRelative(phiHbyA);
+
+if (p.needReference())
+{
+    fvc::makeRelative(phiHbyA, U);
+    adjustPhi(phiHbyA, U, p);
+    fvc::makeAbsolute(phiHbyA, U);
+}
+
+tmp<volScalarField> rAtU(rAU);
+volScalarField& rAtUField = const_cast<volScalarField&>(rAtU());
+
+if (pimple.consistent())
+{
+    rAtU = 1.0/max(1.0/rAU - UEqn.H1(), 0.1/rAU);
+    phiHbyA +=
+        fvc::interpolate(rAtUField - rAU)*fvc::snGrad(p)*mesh.magSf();
+    HbyA -= (rAU - rAtUField)*fvc::grad(p);
+}
+
+if (pimple.nCorrPiso() <= 1)
+{
+    tUEqn.clear();
+}
+
+// Update the pressure BCs to ensure flux consistency
+constrainPressure(p, U, phiHbyA, rAtUField, MRF);
+
+// Non-orthogonal pressure corrector loop
+while (pimple.correctNonOrthogonal())
+{
+    fvScalarMatrix pEqn
+    (
+        fvm::laplacian(rAtUField, p) == fvc::div(phiHbyA)
+    );
+
+    pEqn.setReference
+    (
+        pressureReference.refCell(),
+        pressureReference.refValue()
+    );
+
+    pEqn.solve();
+
+    if (pimple.finalNonOrthogonalIter())
+    {
+        surfaceScalarField phiFlux(pEqn.flux());
+
+        bool gpuUpdatedPhi = false;
+        Foam::gpu::DeviceField<surfaceScalarField>* phiDevPtr = nullptr;
+
+        if (useGpuFieldOps && gpuContext.ready())
+        {
+            word gpuError;
+            Foam::gpu::OperationStats phiStats;
+
+            phiDevPtr = &gpuRegistry.getOrCreate(phi);
+            Foam::gpu::DeviceField<surfaceScalarField> phiHbyADev(phiHbyA);
+            Foam::gpu::DeviceField<surfaceScalarField> fluxDev(phiFlux);
+
+            bool ok =
+                phiDevPtr->syncHostToDevice(gpuContext, gpuError)
+             && phiHbyADev.syncHostToDevice(gpuContext, gpuError)
+             && fluxDev.syncHostToDevice(gpuContext, gpuError)
+             && subtractSurfaceScalarFields
+                (
+                    gpuContext,
+                    *phiDevPtr,
+                    phiHbyADev,
+                    fluxDev,
+                    gpuError,
+                    &phiStats
+                );
+
+            if (ok)
+            {
+                phiDevPtr->markDeviceDirty();
+                ok = phiDevPtr->syncDeviceToHost(gpuContext, gpuError);
+            }
+
+            if (ok)
+            {
+                gpuUpdatedPhi = true;
+                if (logGpuFieldOps)
+                {
+                    Info<< "cuda phi update: " << phiStats.gpuMilliseconds
+                        << " ms" << nl;
+                }
+            }
+            else if (!gpuError.empty())
+            {
+                WarningInFunction
+                    << "GPU phi update failed: " << gpuError << nl << endl;
+            }
+        }
+
+        if (!gpuUpdatedPhi)
+        {
+            phi = phiHbyA - phiFlux;
+
+            if (phiDevPtr)
+            {
+                phiDevPtr->markHostDirty();
+            }
+        }
+    }
+}
+
+#include "continuityErrs.H"
+
+// Explicitly relax pressure for momentum corrector
+p.relax();
+
+tmp<volVectorField> gradPTmp(fvc::grad(p));
+volVectorField& gradP = gradPTmp.ref();
+
+bool gpuUpdatedU = false;
+Foam::gpu::DeviceField<volVectorField>* uDevPtr = nullptr;
+
+if (useGpuFieldOps && gpuContext.ready())
+{
+    word gpuError;
+    Foam::gpu::OperationStats uStats;
+
+    uDevPtr = &gpuRegistry.getOrCreate(U);
+    Foam::gpu::DeviceField<volVectorField> hbyADev(HbyA);
+    Foam::gpu::DeviceField<volScalarField> rAtUDev(rAtUField);
+    Foam::gpu::DeviceField<volVectorField> gradPDev(gradP);
+
+    bool ok =
+        uDevPtr->syncHostToDevice(gpuContext, gpuError)
+     && hbyADev.syncHostToDevice(gpuContext, gpuError)
+     && rAtUDev.syncHostToDevice(gpuContext, gpuError)
+     && gradPDev.syncHostToDevice(gpuContext, gpuError)
+     && velocityCorrector
+        (
+            gpuContext,
+            *uDevPtr,
+            hbyADev,
+            rAtUDev,
+            gradPDev,
+            gpuError,
+            &uStats
+        );
+
+    if (ok)
+    {
+        uDevPtr->markDeviceDirty();
+        ok = uDevPtr->syncDeviceToHost(gpuContext, gpuError);
+    }
+
+    if (ok)
+    {
+        gpuUpdatedU = true;
+        if (logGpuFieldOps)
+        {
+            Info<< "cuda U update: " << uStats.gpuMilliseconds << " ms" << nl;
+        }
+    }
+    else if (!gpuError.empty())
+    {
+        WarningInFunction
+            << "GPU velocity update failed: " << gpuError << nl << endl;
+    }
+}
+
+if (!gpuUpdatedU)
+{
+    U = HbyA - rAtUField*gradP;
+
+    if (uDevPtr)
+    {
+        uDevPtr->markHostDirty();
+    }
+}
+
+gradPTmp.clear();
+
+U.correctBoundaryConditions();
+fvConstraints.constrain(U);
+
+// Correct Uf if the mesh is moving
+fvc::correctUf(Uf, U, phi, MRF);
+
+// Make the fluxes relative to the mesh motion
+fvc::makeRelative(phi, U);

--- a/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H
@@ -38,9 +38,58 @@ constrainPressure(p, U, phiHbyA, rAtUField, MRF);
 // Non-orthogonal pressure corrector loop
 while (pimple.correctNonOrthogonal())
 {
+    bool usedGpuLap = false;
+    Foam::gpu::OperationStats lapStats;
+    word gpuLapError;
+    tmp<fvScalarMatrix> tGpuLap;
+
+    if (useGpuFieldOps && gpuContext.ready())
+    {
+        tGpuLap = Foam::gpu::fvm::laplacian
+        (
+            gpuContext,
+            gpuRegistry,
+            rAtUField,
+            p,
+            usedGpuLap,
+            gpuLapError,
+            logGpuFieldOps ? &lapStats : nullptr
+        );
+
+        if (!usedGpuLap && !gpuLapError.empty())
+        {
+            WarningInFunction
+                << "GPU fvm::laplacian() fallback: "
+                << gpuLapError << nl << endl;
+        }
+    }
+
+    tmp<fvScalarMatrix> tLap;
+    if (usedGpuLap)
+    {
+        if (logGpuFieldOps)
+        {
+            gpuOpStats.append
+            (
+                {
+                    runTime.timeName(),
+                    word("fvmLaplacian"),
+                    lapStats.gpuMilliseconds
+                }
+            );
+        }
+
+        tLap = std::move(tGpuLap);
+    }
+    else
+    {
+        tLap = fvm::laplacian(rAtUField, p);
+    }
+
     fvScalarMatrix pEqn
     (
-        fvm::laplacian(rAtUField, p) == fvc::div(phiHbyA)
+        tLap
+     == fvc::div(phiHbyA)
     );
 
     pEqn.setReference

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -5,28 +5,185 @@
     \\  /    A nd           | Copyright (C) 2025
      \\/     M anipulation  |
 -------------------------------------------------------------------------------
-   Description
-       GPU-development staging solver.  For now this simply re-uses the
-       upstream pimpleFoam implementation so that build infrastructure is in
-       place for future GPU-specific work that will live alongside (not in
-       place of) the CPU code.  To enable the GPU preconditioner defaults
-       (colour + CG pipelining), include the following in system/fvSolution:
+Application
+    pimpleFoamGPU
 
-         solvers
-         {
-             p
-             {
-                 solver          cudaPCG;
-                 preconditioner  colour;
-                 colourOmega     0.65;
-                 colourBackwardOmega 0.85;
-                 colourDiagFloor 1e-12;
-                 usePipelinedCG  true;
-                 logIterationStats true;
-             }
-         }
+Description
+    Transient incompressible solver mirroring pimpleFoam with additional GPU
+    plumbing.  Device-resident field buffers are registered after field
+    creation; subsequent GPU kernels can operate directly on those buffers
+    while the CPU path remains unchanged when the GPU backend is unavailable.
+
 \*---------------------------------------------------------------------------*/
 
-#include "pimpleFoam.C"
+#include "fvCFD.H"
+#include "viscosityModel.H"
+#include "incompressibleMomentumTransportModels.H"
+#include "pimpleControl.H"
+#include "pressureReference.H"
+#include "CorrectPhi.H"
+#include "fvModels.H"
+#include "fvConstraints.H"
+#include "localEulerDdtScheme.H"
+#include "fvcSmooth.H"
+#include "DeviceField.H"
+#include "GpuContext.H"
+#include "FieldOps.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace
+{
+
+inline void registerGpuFields
+(
+    Foam::gpu::FieldRegistry& registry,
+    Foam::gpu::Context& context,
+    Foam::volVectorField& U,
+    Foam::volScalarField& p,
+    Foam::surfaceScalarField& phi
+)
+{
+    word error;
+
+    auto& uDevice = registry.getOrCreate(U);
+    auto& pDevice = registry.getOrCreate(p);
+    auto& phiDevice = registry.getOrCreate(phi);
+
+    if (context.ready())
+    {
+        if (!uDevice.syncHostToDevice(context, error))
+        {
+            WarningInFunction << "U host->device sync failed: " << error << nl;
+        }
+
+        if (!pDevice.syncHostToDevice(context, error))
+        {
+            WarningInFunction << "p host->device sync failed: " << error << nl;
+        }
+
+        if (!phiDevice.syncHostToDevice(context, error))
+        {
+            WarningInFunction << "phi host->device sync failed: " << error << nl;
+        }
+    }
+    else
+    {
+        WarningInFunction
+            << "GPU context unavailable – continuing with CPU execution" << nl;
+    }
+}
+
+} // namespace
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+int main(int argc, char *argv[])
+{
+    #include "postProcess.H"
+
+    #include "setRootCaseLists.H"
+    #include "createTime.H"
+    #include "createMesh.H"
+    #include "initContinuityErrs.H"
+    #include "createDyMControls.H"
+    #include "createFields.H"
+    #include "createUfIfPresent.H"
+
+    Foam::gpu::Context& gpuContext = Foam::gpu::globalContext();
+    Foam::gpu::FieldRegistry& gpuRegistry =
+        Foam::gpu::FieldRegistry::New(mesh);
+
+    registerGpuFields(gpuRegistry, gpuContext, U, p, phi);
+
+    const Switch useGpuFieldOps
+    (
+        pimple.dict().lookupOrDefault<Switch>("useGpuFieldOps", false)
+    );
+
+    const Switch logGpuFieldOps
+    (
+        pimple.dict().lookupOrDefault<Switch>("logGpuFieldOps", false)
+    );
+
+    turbulence->validate();
+
+    if (!LTS)
+    {
+        #include "CourantNo.H"
+        #include "setInitialDeltaT.H"
+    }
+
+    Info<< "\nStarting time loop\n" << endl;
+
+    while (pimple.run(runTime))
+    {
+        #include "readDyMControls.H"
+
+        if (LTS)
+        {
+            #include "setRDeltaT.H"
+        }
+        else
+        {
+            #include "CourantNo.H"
+            #include "setDeltaT.H"
+        }
+
+        fvModels.preUpdateMesh();
+        mesh.update();
+        runTime++;
+
+        Info<< "Time = " << runTime.userTimeName() << nl << endl;
+
+        while (pimple.loop())
+        {
+            if (pimple.firstPimpleIter() || moveMeshOuterCorrectors)
+            {
+                mesh.move();
+
+                if (mesh.changing())
+                {
+                    MRF.update();
+
+                    if (correctPhi)
+                    {
+                        #include "correctPhi.H"
+                    }
+
+                    if (checkMeshCourantNo)
+                    {
+                        #include "meshCourantNo.H"
+                    }
+                }
+            }
+
+            fvModels.correct();
+
+            #include "UEqn.H"
+
+            while (pimple.correct())
+            {
+                #include "pEqnGPU.H"
+            }
+
+            if (pimple.turbCorr())
+            {
+                viscosity->correct();
+                turbulence->correct();
+            }
+        }
+
+        runTime.write();
+
+        Info<< "ExecutionTime = " << runTime.elapsedCpuTime() << " s"
+            << "  ClockTime = " << runTime.elapsedClockTime() << " s"
+            << nl << endl;
+    }
+
+    Info<< "End\n" << endl;
+    return 0;
+}
+
 
 // ************************************************************************* //

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -29,8 +29,18 @@ Description
 #include "DeviceField.H"
 #include "GpuContext.H"
 #include "FieldOps.H"
+#include "DynamicList.H"
+#include "OFstream.H"
+#include "OSspecific.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+struct GpuOpRecord
+{
+    Foam::word timeName;
+    Foam::word operation;
+    Foam::scalar milliseconds;
+};
 
 namespace
 {
@@ -106,6 +116,8 @@ int main(int argc, char *argv[])
         pimple.dict().lookupOrDefault<Switch>("logGpuFieldOps", false)
     );
 
+    DynamicList<GpuOpRecord> gpuOpStats;
+
     turbulence->validate();
 
     if (!LTS)
@@ -118,6 +130,7 @@ int main(int argc, char *argv[])
 
     while (pimple.run(runTime))
     {
+        gpuOpStats.clear();
         #include "readDyMControls.H"
 
         if (LTS)
@@ -172,6 +185,19 @@ int main(int argc, char *argv[])
                 viscosity->correct();
                 turbulence->correct();
             }
+        }
+
+        if (logGpuFieldOps && gpuOpStats.size())
+        {
+            const fileName logDir = runTime.path()/"postProcessing"/"gpuFieldOps"/runTime.timeName();
+            mkDir(logDir);
+            OFstream os(logDir/"stats.csv");
+            os<< "operation,milliseconds" << '\n';
+            for (const GpuOpRecord& rec : gpuOpStats)
+            {
+                os<< rec.operation << ',' << rec.milliseconds << '\n';
+            }
+            gpuOpStats.clear();
         }
 
         runTime.write();

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -9,7 +9,22 @@
        GPU-development staging solver.  For now this simply re-uses the
        upstream pimpleFoam implementation so that build infrastructure is in
        place for future GPU-specific work that will live alongside (not in
-       place of) the CPU code.
+       place of) the CPU code.  To enable the GPU preconditioner defaults
+       (colour + CG pipelining), include the following in system/fvSolution:
+
+         solvers
+         {
+             p
+             {
+                 solver          cudaPCG;
+                 preconditioner  colour;
+                 colourOmega     0.65;
+                 colourBackwardOmega 0.85;
+                 colourDiagFloor 1e-12;
+                 usePipelinedCG  true;
+                 logIterationStats true;
+             }
+         }
 \*---------------------------------------------------------------------------*/
 
 #include "pimpleFoam.C"

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -30,9 +30,12 @@ Description
 #include "GpuContext.H"
 #include "FieldOps.H"
 #include "FvOperators.H"
+#include "KernelCache.H"
 #include "DynamicList.H"
 #include "OFstream.H"
 #include "OSspecific.H"
+#include <map>
+#include <fstream>
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -41,6 +44,12 @@ struct GpuOpRecord
     Foam::word timeName;
     Foam::word operation;
     Foam::scalar milliseconds;
+};
+
+struct GpuOpAggregate
+{
+    Foam::label samples{0};
+    Foam::scalar totalMilliseconds{0};
 };
 
 namespace
@@ -112,10 +121,57 @@ int main(int argc, char *argv[])
         pimple.dict().lookupOrDefault<Switch>("useGpuFieldOps", false)
     );
 
+    const Switch useGpuDdt
+    (
+        pimple.dict().lookupOrDefault<Switch>("useGpuDdt", true)
+    );
+
+    const Switch useGpuDiv
+    (
+        pimple.dict().lookupOrDefault<Switch>("useGpuDiv", true)
+    );
+
     const Switch logGpuFieldOps
     (
         pimple.dict().lookupOrDefault<Switch>("logGpuFieldOps", false)
     );
+
+    const Switch forceCpuPressureCorrector
+    (
+        pimple.dict().lookupOrDefault<Switch>
+        (
+            "forceCpuPressureCorrector",
+            false
+        )
+    );
+
+    const Switch useGpuCudaGraphs
+    (
+        pimple.dict().lookupOrDefault<Switch>("useGpuCudaGraphs", false)
+    );
+
+    const bool graphsEnvOptIn = Foam::gpu::graphsEnabled();
+    const bool solverGraphsOptIn = static_cast<bool>(useGpuCudaGraphs);
+    const bool graphsSupported = Foam::gpu::graphsSupported();
+    const bool graphsRequested = graphsEnvOptIn || solverGraphsOptIn;
+
+    if (graphsRequested && !graphsSupported)
+    {
+        WarningInFunction
+            << "PIMPLE.useGpuCudaGraphs requested but CUDA Graph support is"
+            << " disabled in this build" << nl;
+    }
+
+    Foam::gpu::setCudaGraphsRequested(graphsSupported && graphsRequested);
+    const bool graphsActive = Foam::gpu::graphsEnabled();
+
+    Info<< "GPU field ops: use=" << (useGpuFieldOps ? "on" : "off")
+        << ", log=" << (logGpuFieldOps ? "on" : "off")
+        << ", graphs=" << (graphsActive ? "on" : "off")
+        << ", useGpuDdt=" << (useGpuDdt ? "on" : "off")
+        << ", useGpuDiv=" << (useGpuDiv ? "on" : "off")
+        << ", forceCpuPressure=" << (forceCpuPressureCorrector ? "on" : "off")
+        << nl;
 
     DynamicList<GpuOpRecord> gpuOpStats;
 
@@ -185,19 +241,133 @@ int main(int argc, char *argv[])
             {
                 viscosity->correct();
                 turbulence->correct();
+
+                if (logGpuFieldOps)
+                {
+                    tmp<volScalarField> tK = turbulence->k();
+                    tmp<volScalarField> tEps = turbulence->epsilon();
+                    tmp<volScalarField> tNut = turbulence->nut();
+
+                    const volScalarField& kField = tK();
+                    const volScalarField& epsField = tEps();
+                    const volScalarField& nutField = tNut();
+
+                    Info<< "turbulence k stats: min=" << gMin(kField.internalField())
+                        << ", max=" << gMax(kField.internalField())
+                        << ", mean=" << gAverage(kField.internalField()) << nl;
+                    Info<< "turbulence epsilon stats: min="
+                        << gMin(epsField.internalField())
+                        << ", max=" << gMax(epsField.internalField())
+                        << ", mean=" << gAverage(epsField.internalField()) << nl;
+                    Info<< "turbulence nut stats: min=" << gMin(nutField.internalField())
+                        << ", max=" << gMax(nutField.internalField())
+                        << ", mean=" << gAverage(nutField.internalField()) << nl;
+
+                    tK.clear();
+                    tEps.clear();
+                    tNut.clear();
+
+                    const vectorField& uInternal = U.internalField();
+                    const scalarField& cellVolumes = U.mesh().V();
+                    scalar volWeightedMag = 0.0;
+                    scalar totalVolume = 0.0;
+                    scalar maxMagU = 0.0;
+                    forAll(uInternal, celli)
+                    {
+                        const scalar magU = mag(uInternal[celli]);
+                        const scalar w = cellVolumes[celli];
+                        volWeightedMag += w*magU;
+                        totalVolume += w;
+                        maxMagU = max(maxMagU, magU);
+                    }
+                    totalVolume = max(totalVolume, VSMALL);
+                    Info<< "velocity |U| stats: max=" << maxMagU
+                        << ", volMean=" << volWeightedMag/totalVolume << nl;
+                }
             }
         }
 
         if (logGpuFieldOps && gpuOpStats.size())
         {
-            const fileName logDir = runTime.path()/"postProcessing"/"gpuFieldOps"/runTime.timeName();
-            mkDir(logDir);
-            OFstream os(logDir/"stats.csv");
-            os<< "operation,milliseconds" << '\n';
+            std::map<word, GpuOpAggregate> aggregates;
             for (const GpuOpRecord& rec : gpuOpStats)
             {
-                os<< rec.operation << ',' << rec.milliseconds << '\n';
+                GpuOpAggregate& agg = aggregates[rec.operation];
+                agg.samples++;
+                agg.totalMilliseconds += rec.milliseconds;
             }
+
+            label cpuFallbackSamples = 0;
+            for (const auto& kv : aggregates)
+            {
+                const word& op = kv.first;
+                if (op.size() >= 4 && op.substr(op.size() - 4) == "_cpu")
+                {
+                    cpuFallbackSamples += kv.second.samples;
+                }
+            }
+
+            const fileName baseDir = runTime.path()/"postProcessing"/"gpuFieldOps";
+            mkDir(baseDir);
+            const fileName timeDir = baseDir/runTime.timeName();
+            mkDir(timeDir);
+
+            {
+                OFstream raw(timeDir/"stats_raw.csv");
+                raw<< "operation,milliseconds" << '\n';
+                for (const GpuOpRecord& rec : gpuOpStats)
+                {
+                    raw<< rec.operation << ',' << rec.milliseconds << '\n';
+                }
+            }
+
+            {
+                OFstream detail(timeDir/"stats.csv");
+                detail<< "operation,samples,totalMilliseconds,averageMilliseconds" << '\n';
+                for (const auto& kv : aggregates)
+                {
+                    const GpuOpAggregate& agg = kv.second;
+                    const scalar average = agg.samples
+                        ? agg.totalMilliseconds/agg.samples
+                        : 0.0;
+                    detail<< kv.first << ',' << agg.samples << ','
+                          << agg.totalMilliseconds << ',' << average << '\n';
+                }
+            }
+
+            const fileName summaryPath = baseDir/"summary.csv";
+            const bool summaryExists = isFile(summaryPath);
+            std::ofstream summary(summaryPath.c_str(), std::ios::out | std::ios::app);
+            if (!summary)
+            {
+                WarningInFunction
+                    << "Unable to open " << summaryPath << " for append" << nl;
+            }
+            else
+            {
+                if (!summaryExists)
+                {
+                    summary<< "time,operation,samples,totalMilliseconds,averageMilliseconds" << '\n';
+                }
+
+                for (const auto& kv : aggregates)
+                {
+                    const GpuOpAggregate& agg = kv.second;
+                    const scalar average = agg.samples
+                        ? agg.totalMilliseconds/agg.samples
+                        : 0.0;
+                    summary<< runTime.timeName() << ',' << kv.first << ','
+                           << agg.samples << ',' << agg.totalMilliseconds << ','
+                           << average << '\n';
+                }
+            }
+
+            if (cpuFallbackSamples)
+            {
+                Info<< "GPU fallbacks this step: " << cpuFallbackSamples
+                    << " (see " << timeDir << ")" << nl;
+            }
+
             gpuOpStats.clear();
         }
 

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -29,6 +29,7 @@ Description
 #include "DeviceField.H"
 #include "GpuContext.H"
 #include "FieldOps.H"
+#include "FvOperators.H"
 #include "DynamicList.H"
 #include "OFstream.H"
 #include "OSspecific.H"
@@ -173,7 +174,7 @@ int main(int argc, char *argv[])
 
             fvModels.correct();
 
-            #include "UEqn.H"
+            #include "UEqnGPU.H"
 
             while (pimple.correct())
             {

--- a/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
+++ b/applications/solvers/incompressible/pimpleFoamGPU/pimpleFoamGPU.C
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2025
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+   Description
+       GPU-development staging solver.  For now this simply re-uses the
+       upstream pimpleFoam implementation so that build infrastructure is in
+       place for future GPU-specific work that will live alongside (not in
+       place of) the CPU code.
+\*---------------------------------------------------------------------------*/
+
+#include "pimpleFoam.C"
+
+// ************************************************************************* //

--- a/bin/check_colour_summary.py
+++ b/bin/check_colour_summary.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+from pathlib import Path
+import sys
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate cudaPCG colour sweep summary metrics.")
+    parser.add_argument("--file", required=True, help="Path to summary.csv produced by gpu_colour_sweep.sh")
+    parser.add_argument("--max-rel", type=float, default=1e-2, help="Maximum allowed relL2(Ux)")
+    parser.add_argument("--max-iter", type=float, default=1000.0, help="Maximum allowed PCG iteration count")
+    parser.add_argument("--max-time", type=float, default=300.0, help="Maximum allowed ExecutionTime (seconds)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary_path = Path(args.file)
+    if not summary_path.is_file():
+        print(f"[check_colour_summary] Missing summary file: {summary_path}", file=sys.stderr)
+        return 2
+
+    failures = []
+    with summary_path.open('r', encoding='utf-8') as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            case = row.get('case', '<unknown>')
+            rel = row.get('relL2_Ux', '')
+            pcg_iter = row.get('pcgIterations', '')
+            exec_time = row.get('executionTime', '')
+
+            try:
+                rel_val = float(rel)
+            except ValueError:
+                rel_val = float('inf')
+            if rel_val > args.max_rel:
+                failures.append(f"{case}: relL2_Ux={rel_val:.6e} > {args.max_rel:.6e}")
+
+            try:
+                iter_val = float(pcg_iter)
+            except ValueError:
+                iter_val = float('inf')
+            if iter_val > args.max_iter:
+                failures.append(f"{case}: pcgIterations={iter_val} > {args.max_iter}")
+
+            try:
+                time_val = float(exec_time)
+            except ValueError:
+                time_val = float('inf')
+            if time_val > args.max_time:
+                failures.append(f"{case}: ExecutionTime={time_val}s > {args.max_time}s")
+
+    if failures:
+        print("[check_colour_summary] FAIL:", file=sys.stderr)
+        for entry in failures:
+            print(f"  - {entry}", file=sys.stderr)
+        return 1
+
+    print(f"[check_colour_summary] PASS: {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/gpu_colour_sweep.sh
+++ b/bin/gpu_colour_sweep.sh
@@ -19,6 +19,11 @@ Options:
   --pipelined           Enable pipelined CG path (sets usePipelinedCG true)
   --cuda-graph          Enable CUDA Graph replay (sets useCudaGraph true)
   --graph-warmup N      Iterations before capturing CUDA Graph (default: 5)
+  --log-iter            Enable solver-side iteration timing (`logIterationStats true`)
+  --summary-check       Run regression checks on the produced summary
+  --max-rel VALUE       Max allowed relL2(Ux) when --summary-check is used (default: 1e-2)
+  --max-iter VALUE      Max allowed PCG iterations when --summary-check is used (default: 1000)
+  --max-time VALUE      Max allowed ExecutionTime [s] when --summary-check is used (default: 300)
   --help                Show this message
 EOF
 }
@@ -84,6 +89,11 @@ threshold=1e-2
 enable_pipelined=false
 enable_cuda_graph=false
 graph_warmup=5
+enable_iter_logging=false
+enable_summary_check=false
+check_rel=1e-2
+check_iter=1000
+check_time=300
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -99,6 +109,11 @@ while [[ $# -gt 0 ]]; do
         --pipelined) enable_pipelined=true; shift ;;
         --cuda-graph) enable_cuda_graph=true; shift ;;
         --graph-warmup) graph_warmup="$2"; shift 2;;
+        --log-iter) enable_iter_logging=true; shift ;;
+        --summary-check) enable_summary_check=true; shift ;;
+        --max-rel) check_rel="$2"; shift 2;;
+        --max-iter) check_iter="$2"; shift 2;;
+        --max-time) check_time="$2"; shift 2;;
         --help|-h) usage; exit 0;;
         *) echo "Unknown option: $1" >&2; usage; exit 2;;
     esac
@@ -186,6 +201,9 @@ for omega in "${omegas[@]}"; do
             if [[ "$enable_cuda_graph" == true ]]; then
                 foam_dict_set "$dict" "solvers/p/useCudaGraph" "true"
                 foam_dict_set "$dict" "solvers/p/cudaGraphWarmup" "$graph_warmup"
+            fi
+            if [[ "$enable_iter_logging" == true ]]; then
+                foam_dict_set "$dict" "solvers/p/logIterationStats" "true"
             fi
 
             foam_dict_set "$dict" "solvers/pFinal/colourOmega" "$omega"
@@ -304,3 +322,11 @@ PY
 done
 
 echo "Sweep complete. Summary: $summary"
+
+if [[ "$enable_summary_check" == true ]]; then
+    python3 "$(dirname "$0")/check_colour_summary.py" \
+        --file "$summary" \
+        --max-rel "$check_rel" \
+        --max-iter "$check_iter" \
+        --max-time "$check_time"
+fi

--- a/bin/gpu_colour_sweep.sh
+++ b/bin/gpu_colour_sweep.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Sweep coloured cudaPCG preconditioner parameters on pitzDaily-like cases.
+set -eo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: gpu_colour_sweep.sh [options]
+
+Options:
+  --run-root DIR        Run root containing template case and logs (default: /home/xiaozhou/OpenFOAM/xiaozhou-10/run)
+  --template NAME       Template case under run-root (default: pitzDaily_clean)
+  --cpu-case NAME       CPU reference case (default: pitzDaily_cpu)
+  --prefix NAME         Prefix for generated cases/logs (default: pitzDaily_gpu_colour)
+  --omegas LIST         Forward colour relaxation list (comma-separated, default: 0.65,0.75,0.85,0.95)
+  --backward LIST       Backward relaxation list (comma-separated, default: reuse --omegas)
+  --floors LIST         Diagonal floor list (comma-separated, default: 1e-12,5e-12,1e-11)
+  --residual-every N    Residual logging stride (default: 1)
+  --threshold VALUE     Relative L2(Ux) threshold (default: 1e-2)
+  --pipelined           Enable pipelined CG path (sets usePipelinedCG true)
+  --cuda-graph          Enable CUDA Graph replay (sets useCudaGraph true)
+  --graph-warmup N      Iterations before capturing CUDA Graph (default: 5)
+  --help                Show this message
+EOF
+}
+
+sanitize_token() {
+    local token="$1"
+    token="${token//./p}"
+    token="${token//-/m}"
+    token="${token//+/p}"
+    printf '%s' "$token"
+}
+
+remove_path() {
+    local target="$1"
+    python3 - "$target" <<'PY'
+import os
+import shutil
+import sys
+
+path = sys.argv[1]
+if os.path.isdir(path):
+    shutil.rmtree(path)
+PY
+}
+
+replace_file_entry() {
+    local dict="$1"
+    local key="$2"
+    local value="$3"
+    python3 - "$dict" "$key" "$value" <<'PY'
+import re
+import sys
+
+path, key, value = sys.argv[1:4]
+with open(path, 'r', encoding='utf-8') as fh:
+    text = fh.read()
+pattern = rf'({re.escape(key)})\s+[^;\n]+;'
+replacement = rf'\1 "{value}";'
+updated, count = re.subn(pattern, replacement, text, count=1)
+if count == 0:
+    raise SystemExit(f"Failed to set {key} in {path}")
+with open(path, 'w', encoding='utf-8') as fh:
+    fh.write(updated)
+PY
+}
+
+foam_dict_set() {
+    local dict="$1"
+    local entry="$2"
+    local value="$3"
+    foamDictionary "$dict" -entry "$entry" -set "$value" >/dev/null
+}
+
+run_root=/home/xiaozhou/OpenFOAM/xiaozhou-10/run
+template_case=pitzDaily_clean
+cpu_case=pitzDaily_cpu
+prefix=pitzDaily_gpu_colour
+omega_list="0.65,0.75,0.85,0.95"
+backward_list=""
+floor_list="1e-12,5e-12,1e-11"
+res_stride=1
+threshold=1e-2
+enable_pipelined=false
+enable_cuda_graph=false
+graph_warmup=5
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --run-root) run_root="$2"; shift 2;;
+        --template) template_case="$2"; shift 2;;
+        --cpu-case) cpu_case="$2"; shift 2;;
+        --prefix) prefix="$2"; shift 2;;
+        --omegas) omega_list="$2"; shift 2;;
+        --backward) backward_list="$2"; shift 2;;
+        --floors) floor_list="$2"; shift 2;;
+        --residual-every) res_stride="$2"; shift 2;;
+        --threshold) threshold="$2"; shift 2;;
+        --pipelined) enable_pipelined=true; shift ;;
+        --cuda-graph) enable_cuda_graph=true; shift ;;
+        --graph-warmup) graph_warmup="$2"; shift 2;;
+        --help|-h) usage; exit 0;;
+        *) echo "Unknown option: $1" >&2; usage; exit 2;;
+    esac
+done
+
+IFS=',' read -r -a omegas <<<"$omega_list"
+if [[ -n "$backward_list" ]]; then
+    IFS=',' read -r -a backward_omegas <<<"$backward_list"
+else
+    backward_omegas=("${omegas[@]}")
+fi
+IFS=',' read -r -a diag_floors <<<"$floor_list"
+
+timestamp=$(date +%Y%m%d-%H%M%S)
+log_root="$run_root/logs/${prefix}_${timestamp}"
+mkdir -p "$log_root"
+summary="$log_root/summary.csv"
+echo "case,omega,backwardOmega,diagFloor,compareStatus,relL2_Ux,nColours,minColourSize,maxColourSize,avgColourSize,disableCount,pcgIterations,pcgFinalResidual,executionTime,clockTime,colourStats,residualLog" >"$summary"
+
+set +u
+
+template_path="$run_root/$template_case"
+cpu_path="$run_root/$cpu_case"
+compare_script="$run_root/scripts/compare_latest_U.sh"
+
+if [[ ! -d "$template_path" ]]; then
+    echo "Template case not found: $template_path" >&2
+    exit 1
+fi
+if [[ ! -d "$cpu_path" ]]; then
+    echo "CPU reference case not found: $cpu_path" >&2
+    exit 1
+fi
+if [[ ! -x "$compare_script" ]]; then
+    echo "compare_latest_U.sh not found at $compare_script" >&2
+    exit 1
+fi
+
+echo "Writing logs to $log_root"
+
+for omega in "${omegas[@]}"; do
+    for back in "${backward_omegas[@]}"; do
+        for floor_val in "${diag_floors[@]}"; do
+            token_o=$(sanitize_token "$omega")
+            token_b=$(sanitize_token "$back")
+            token_f=$(sanitize_token "$floor_val")
+            case_name="${prefix}_o${token_o}_b${token_b}_d${token_f}"
+            case_path="$run_root/$case_name"
+            case_log="$log_root/$case_name"
+            mkdir -p "$case_log"
+
+            echo "--> Running $case_name (omega=$omega, back=$back, floor=$floor_val)"
+
+            remove_path "$case_path"
+            cp -a "$template_path" "$case_path"
+
+            (
+                cd "$case_path"
+                rm -f log.pimpleFoam log.* || true
+                if command -v foamClearCase >/dev/null 2>&1; then
+                    foamClearCase || true
+                else
+                    rm -rf 0.[0-9]* [1-9]* processor* postProcessing || true
+                fi
+            )
+
+            dict="$case_path/system/fvSolution"
+            foam_dict_set "$dict" "solvers/p/preconditioner" "colour"
+            foam_dict_set "$dict" "solvers/pFinal/preconditioner" "colour"
+            foam_dict_set "$dict" "solvers/p/colourOmega" "$omega"
+            foam_dict_set "$dict" "solvers/p/colourBackwardOmega" "$back"
+            foam_dict_set "$dict" "solvers/p/colourDiagFloor" "$floor_val"
+            foam_dict_set "$dict" "solvers/p/reportGpuStats" "true"
+            foam_dict_set "$dict" "solvers/p/logColourStats" "true"
+            foam_dict_set "$dict" "solvers/p/logResidualTrajectory" "true"
+            foam_dict_set "$dict" "solvers/p/residualLogEvery" "$res_stride"
+            foam_dict_set "$dict" "solvers/p/residualLogFile" "postProcessing/cudaPCG/residual.csv"
+            replace_file_entry "$dict" "residualLogFile" "postProcessing/cudaPCG/residual.csv"
+            foam_dict_set "$dict" "solvers/p/colourStatsFile" "postProcessing/cudaPCG/colour_stats.csv"
+            replace_file_entry "$dict" "colourStatsFile" "postProcessing/cudaPCG/colour_stats.csv"
+            foam_dict_set "$dict" "solvers/p/gpuDevice" "0"
+            if [[ "$enable_pipelined" == true ]]; then
+                foam_dict_set "$dict" "solvers/p/usePipelinedCG" "true"
+            fi
+            if [[ "$enable_cuda_graph" == true ]]; then
+                foam_dict_set "$dict" "solvers/p/useCudaGraph" "true"
+                foam_dict_set "$dict" "solvers/p/cudaGraphWarmup" "$graph_warmup"
+            fi
+
+            foam_dict_set "$dict" "solvers/pFinal/colourOmega" "$omega"
+            foam_dict_set "$dict" "solvers/pFinal/colourBackwardOmega" "$back"
+            foam_dict_set "$dict" "solvers/pFinal/colourDiagFloor" "$floor_val"
+
+            (
+                cd "$case_path"
+                chmod +x ./Allrun || true
+                ./Allrun
+            ) | tee "$case_log/Allrun.log"
+
+            compare_status="PASS"
+            if "$compare_script" "$cpu_path" "$case_path" "$threshold" | tee "$case_log/compare.txt"; then
+                :
+            else
+                compare_status="FAIL"
+            fi
+
+            colour_stats_src="$case_path/postProcessing/cudaPCG/colour_stats.csv"
+            residual_src="$case_path/postProcessing/cudaPCG/residual.csv"
+            colour_stats_dest="$case_log/colour_stats.csv"
+            residual_dest="$case_log/residual.csv"
+            if [[ -f "$colour_stats_src" ]]; then
+                cp "$colour_stats_src" "$colour_stats_dest"
+            fi
+            if [[ -f "$residual_src" ]]; then
+                cp "$residual_src" "$residual_dest"
+            fi
+
+            pcg_iters=""
+            pcg_final=""
+            if [[ -f "$residual_dest" ]]; then
+                read -r pcg_iters pcg_final <<<"$(python3 - "$residual_dest" <<'PY'
+import csv
+import sys
+
+path = sys.argv[1]
+last_iter = ""
+last_res = ""
+with open(path, 'r', encoding='utf-8') as fh:
+    reader = csv.reader(row for row in fh if row.strip() and not row.startswith('#'))
+    header = next(reader, None)
+    for row in reader:
+        if len(row) >= 2:
+            last_iter = row[0].strip()
+            last_res = row[1].strip()
+print(f"{last_iter} {last_res}")
+PY
+)"
+            fi
+
+            exec_time=""
+            clock_time=""
+            if [[ -f "$case_path/log.pimpleFoam" ]]; then
+                read -r exec_time clock_time <<<"$(python3 - "$case_path/log.pimpleFoam" <<'PY'
+import sys
+
+path = sys.argv[1]
+exec_time = ""
+clock_time = ""
+with open(path, 'r', encoding='utf-8') as fh:
+    for line in fh:
+        if "ExecutionTime" in line and "ClockTime" in line:
+            parts = line.strip().replace('=', '').split()
+            # Expected format: ExecutionTime value ClockTime value
+            try:
+                idx_exec = parts.index('ExecutionTime')
+                exec_time = parts[idx_exec + 1]
+                idx_clock = parts.index('ClockTime')
+                clock_time = parts[idx_clock + 1]
+            except Exception:
+                continue
+if exec_time:
+    print(f"{exec_time} {clock_time}")
+else:
+    print()
+PY
+)"
+            fi
+
+            colour_line=""
+            if [[ -f "$colour_stats_dest" ]]; then
+                colour_line=$(tail -n 1 "$colour_stats_dest")
+            fi
+
+            n_colours="" min_colour="" max_colour="" avg_colour="" disable_count=""
+            if [[ -n "$colour_line" ]]; then
+                IFS=',' read -r n_colours min_colour max_colour avg_colour _ _ _ _ _ _ _ _ disable_count disable_stages <<<"$colour_line"
+            fi
+
+            rel_l2_ux=""
+            if [[ -f "$case_log/compare.txt" ]]; then
+                rel_l2_ux=$(python3 - "$case_log/compare.txt" <<'PY'
+import re
+import sys
+
+log_path = sys.argv[1]
+ux_value = ""
+with open(log_path, "r", encoding="utf-8") as f:
+    for line in f:
+        if "Ux:" in line:
+            match = re.search(r"相对L2=([0-9eE\+\-\.]+)", line)
+            if match:
+                ux_value = match.group(1)
+                break
+if ux_value:
+    print(ux_value)
+PY
+)
+            fi
+
+            echo "$case_name,$omega,$back,$floor_val,$compare_status,$rel_l2_ux,$n_colours,$min_colour,$max_colour,$avg_colour,$disable_count,$pcg_iters,$pcg_final,$exec_time,$clock_time,$colour_stats_dest,$residual_dest" >>"$summary"
+        done
+    done
+done
+
+echo "Sweep complete. Summary: $summary"

--- a/docs/gpu-colour-preconditioner-20251012.md
+++ b/docs/gpu-colour-preconditioner-20251012.md
@@ -1,0 +1,59 @@
+# Coloured Preconditioner Sweep – 2025-10-12
+
+All runs executed on the development mirror (`feature/gpu-linear-solver`) with `libcudaPCG` built from commit-in-progress. Each sweep case copies `pitzDaily_clean`, enables the colour preconditioner for `p`, logs GPU telemetry, and compares the final write against the CPU reference (`run/scripts/compare_latest_U.sh ... 1e-2`).
+
+- Driver: `bin/gpu_colour_sweep.sh`
+- Artefacts: `run/logs/pitzDaily_gpu_colour_scan2_20251012-150314/`
+  - `summary.csv` – aggregated parity + colour metrics (see table below)
+  - `*/colour_stats.csv` – per-case colour-set statistics
+  - `*/residual.csv` – per-case residual trajectory (iteration vs. ‖r‖₁/‖b‖)
+  - `*/compare.txt` – parity report for `U`, `p`, `k`, `epsilon`
+
+## Summary statistics (per omega / backward omega trio)
+
+Values averaged across diagonal floors `{1e-12, 5e-12, 1e-11}`. `relL2(Ux)` reported in 1e-5 units for readability; residuals scaled similarly.
+
+| ω_fwd | ω_back | mean relL2(Ux)×1e⁻⁵ | mean PCG iterations | mean final residual ×1e⁻⁷ | notes |
+|------:|-------:|---------------------:|--------------------:|---------------------------:|:------|
+| 0.65  | 0.65   | 2.50 | 91  | 43.8 | Slower decay; higher steady-state residual. |
+| 0.65  | 0.75   | 2.07 | 176 | 29.4 | Improves parity vs. ω_back = 0.65. |
+| **0.65** | **0.85** | **1.36** | **782** | **0.96** | Lowest parity error, residual ≈ 1e⁻⁷. |
+| 0.75  | 0.65   | 3.36 | 38  | 299  | Converges quickly but stalls far above tolerance. |
+| 0.75  | 0.75   | 4.26 | 747 | 2.79 | Stable but parity poorest. |
+| 0.75  | 0.85   | 2.05 | 732 | 2.45 | Acceptable parity; residual O(1e⁻⁷). |
+| 0.85  | 0.65   | 1.93 | 732 | 3.29 | Final residual O(1e⁻⁶); parity moderately low. |
+| 0.85  | 0.75   | 1.43 | 745 | 0.99 | Second-best parity; balanced residual. |
+| 0.85  | 0.85   | 2.62 | 100 | 39.7 | Residual plateaus above 1e⁻⁶. |
+
+Observations:
+- Diagonal floor had negligible effect on parity or convergence in this range.
+- Aggressive backward relaxation (`ω_back ≥ 0.85`) noticeably reduces parity drift; matching ω_forward produced worse residuals.
+- Combinations that left the residual ≥O(1e⁻⁶) also accumulated higher parity error over the time horizon.
+
+## Recommended defaults
+
+- **Forward relaxation (`colourOmega`)**: 0.65  
+- **Backward relaxation (`colourBackwardOmega`)**: 0.85  
+- **Diagonal floor (`colourDiagFloor`)**: 1e-12
+
+These values are now the compilation-time defaults inside `cudaPCG` (overridable from `fvSolution`). They minimise the observed parity error while maintaining residual decay to ≈1e⁻⁷. Future sweeps on larger or non-symmetric cases should reuse the driver script and append results here for traceability.
+
+## Additional validation – pitzDaily_gpu_phase1
+
+- Artefacts: `run/logs/pitzDaily_gpu_phase1_colour_scan2_20251012-183737/`
+  - `summary.csv` (same schema as above) + per-case residual/colour logs.
+- The transient/longer-run case exhibits the same ordering as the steady pitzDaily sweep—`(ω_fwd, ω_back) = (0.65, 0.85)` remains the lowest-drift choice.
+
+| ω_fwd | ω_back | mean relL2(Ux)×1e⁻⁵ | mean PCG iterations | mean final residual ×1e⁻⁶ | mean ExecTime [s] |
+|------:|-------:|---------------------:|--------------------:|---------------------------:|------------------:|
+| 0.65  | 0.65   | 2.50 | 91.0  | 4.38  | 229.089 |
+| 0.65  | 0.75   | 2.07 | 176.0 | 2.94  | 232.375 |
+| **0.65** | **0.85** | **1.36** | **782.0** | **0.10** | **235.307** |
+| 0.75  | 0.65   | 3.35 | 38.0  | 29.95 | 229.385 |
+| 0.75  | 0.75   | 4.26 | 747.0 | 0.28  | 222.972 |
+| 0.75  | 0.85   | 2.05 | 732.0 | 0.25  | 226.754 |
+| 0.85  | 0.65   | 1.93 | 732.0 | 0.33  | 244.257 |
+| 0.85  | 0.75   | 1.43 | 745.0 | 0.10  | 237.860 |
+| 0.85  | 0.85   | 2.62 | 100.0 | 3.97  | 219.951 |
+
+Final residuals are scaled to 1e⁻⁶ for readability; execution times come from the tail `ExecutionTime` line in each `log.pimpleFoam`. The relative ranking mirrors the steady case, lending confidence to the selected defaults.

--- a/docs/gpu-colour-preconditioner-20251012.md
+++ b/docs/gpu-colour-preconditioner-20251012.md
@@ -57,3 +57,33 @@ These values are now the compilation-time defaults inside `cudaPCG` (overridable
 | 0.85  | 0.85   | 2.62 | 100.0 | 3.97  | 219.951 |
 
 Final residuals are scaled to 1e⁻⁶ for readability; execution times come from the tail `ExecutionTime` line in each `log.pimpleFoam`. The relative ranking mirrors the steady case, lending confidence to the selected defaults.
+
+## Targeted low-iteration sweep (2025-10-12 evening)
+
+- Artefacts: `run/logs/pitzDaily_gpu_colour_grid_small_*` (16 runs, single floor `1e-12`).
+- Goal: find `(colourOmega, colourBackwardOmega)` pairs that minimise PCG iterations while keeping rel L2(Ux) ≤ ~4e-5.
+- Observations:
+  * Lowering ω_fwd below 0.55 is risky (parity drifts, execution time unaffected).
+  * ω_fwd=0.65, ω_back=0.80 yields ~77 iterations and the best runtime so far (~231 s) with rel L2≈3.2e-5.
+  * Extreme back-relaxation (ω_back=0.85) still gives the best parity but pushes iterations toward the 800 range.
+
+| ω_fwd | ω_back | iterations | ExecTime [s] | relL2(Ux) |
+|------:|-------:|-----------:|-------------:|-----------:|
+| 0.50 | 0.85 | 66 | 247.60 | 2.22e-05 |
+| 0.55 | 0.70 | 67 | 236.16 | 3.12e-05 |
+| 0.65 | 0.80 | 77 | 230.72 | 3.20e-05 |
+| 0.50 | 0.75 | 84 | 249.60 | 4.40e-05 |
+| 0.55 | 0.75 | 87 | 236.79 | 3.31e-05 |
+| 0.60 | 0.85 | 116 | 238.32 | 3.80e-05 |
+| 0.65 | 0.75 | 176 | 235.50 | 2.07e-05 |
+| 0.65 | 0.70 | 186 | 235.42 | 2.26e-05 |
+| 0.60 | 0.80 | 252 | 242.19 | 3.24e-05 |
+| 0.50 | 0.70 | 721 | 245.93 | 2.75e-05 |
+| 0.60 | 0.70 | 767 | 236.29 | 1.44e-05 |
+| 0.55 | 0.80 | 773 | 234.98 | 2.78e-05 |
+| 0.65 | 0.85 | 782 | 235.14 | 1.36e-05 |
+| 0.60 | 0.75 | 790 | 237.53 | 8.14e-06 |
+| 0.50 | 0.80 | 817 | 245.75 | 1.39e-05 |
+| 0.55 | 0.85 | 829 | 245.46 | 1.05e-05 |
+
+Takeaway: ω_fwd≈0.65 with ω_back≈0.80 is a promising compromise (iterations ≈77, rel L2≈3.2e-5, ExecTime ≈231 s). Further tuning should focus on nudging ω_fwd between 0.6–0.65 and ω_back 0.78–0.82, possibly with adaptive diagonal floors, to recover the 116 s baseline while keeping parity intact.

--- a/docs/gpu-notes.md
+++ b/docs/gpu-notes.md
@@ -3,8 +3,8 @@
 ## Current Baseline
 - Solver: `pimpleFoam` with `cudaPCG` (diagonal preconditioner).
 - Validation case: `pitzDaily_gpu_phase1`.
-- Runtime: ~120 s on GPU after removing per-iteration host/device synchronisation inside the CG loop (CPU reference ~35 s).
-- Average pressure iterations: ~180 per time step (preconditioner still diagonal).
+- Runtime: ~116 s on GPU after removing the per-iteration host/device synchronisation that copied `Ap`/`p` back to the CPU for residual normalisation (CPU reference ~35 s).
+- Average pressure iterations: ~180 per time step (GPU preconditioner work-in-progress; currently falls back to diagonal).
 
 ## Infrastructure Added (2025-10-10)
 - `applications/solvers/incompressible/pimpleFoamGPU` – build target for GPU-specific solver experiments (mirrors the CPU solver for now).
@@ -13,7 +13,7 @@
 - `cudaPCG` now keeps residuals/dots on the device (no vector-size copies each iteration), giving the ~2× runtime reduction above.
 
 ## Next Focus Areas
-1. Implement fully device-resident preconditioning (e.g. ILU/IC with modern cuSPARSE SpSV routines). Initial attempts via the deprecated CSRsv2 path are blocked by the current CUDA toolkit.
+1. Added a GPU symmetric Gauss–Seidel (SGS) preconditioner path: it builds the (D+L) triangular matrix from the symmetric CSR and uses cuSPARSE SpSV for forward/back solves. It’s selectable via `preconditioner SGS` in `fvSolution`. Default remains `diagonal` until we validate robustness and benefit.
 2. Keep field data on the GPU throughout the PIMPLE loop (remove remaining host copies).
 3. Move discretisation kernels into the `_gpu` tree outlined in `~/Downloads/acc_plan.md`.
 

--- a/docs/gpu-notes.md
+++ b/docs/gpu-notes.md
@@ -45,5 +45,6 @@
   - `useCudaGraph` plus optional `cudaGraphWarmup` records the steady-state `cusparseSpMV` into a CUDA Graph after the warm-up stage and replays it on subsequent iterations via a dedicated non-blocking stream.
 - `bin/gpu_colour_sweep.sh` now records PCG iteration counts, final residuals, and Execution/Clock time for each case. Artefacts for the pipelined smoke test sit under `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/`.
 - Observation: on pitzDaily the pipelined+graph path increases parity drift slightly (rel L2(Ux)≈3.3e-5 vs 1.36e-5) and is slower (~245 s vs 235 s). Keep it behind the runtime flag until further tuning, but the infrastructure is in place for Step 2 experiments.
+- A targeted grid sweep (`scripts/run_colour_grid.py`, results under `run/logs/pitzDaily_gpu_colour_grid_small_*`) shows `(colourOmega≈0.65, colourBackwardOmega≈0.80)` drops PCG iterations to ~77 with rel L2≈3.2e-5 and ExecutionTime ≈231 s. Candidate for follow-up heuristics.
 
 These changes keep the CPU code untouched and establish the parallel `_gpu` scaffolding described in the acceleration plan.

--- a/docs/gpu-notes.md
+++ b/docs/gpu-notes.md
@@ -17,4 +17,33 @@
 2. Keep field data on the GPU throughout the PIMPLE loop (remove remaining host copies).
 3. Move discretisation kernels into the `_gpu` tree outlined in `~/Downloads/acc_plan.md`.
 
+## Coloured preconditioner status (2025-10-12)
+- NVRTC compilation fixed; colour kernels now build at runtime and stay active (telemetry and residual logs confirmed zero CPU fallback across the pitzDaily sweep).
+- New telemetry:
+  - `logResidualTrajectory`, `residualLogEvery`, `residualLogFile`
+  - `logColourStats`, `colourStatsFile`
+  - Automatically logs disable reasons, min/max/avg colour-set sizes, and writes CSVs under `postProcessing/cudaPCG/`.
+- Sweep driver: `bin/gpu_colour_sweep.sh`
+  - Produces parameterised runs, captures `compare_latest_U.sh` parity, and writes `summary.csv` + per-case artefacts under `run/logs/<prefix>_<timestamp>/`.
+  - Latest full sweep (27 combos, pitzDaily) lives at `run/logs/pitzDaily_gpu_colour_scan2_20251012-150314/`.
+- Recommended defaults (now baked into `cudaPCG`):
+  - `colourOmega = 0.65`, `colourBackwardOmega = 0.85`, `colourDiagFloor = 1e-12`.
+  - Combination chosen from sweep for lowest relative L2(Ux) (~1.36e-5) with stable residual decay to ~1e-7.
+- When benchmarking, enable telemetry in `system/fvSolution` to capture artefacts, e.g.:
+  ```foam
+  reportGpuStats        true;
+  logColourStats        true;
+  logResidualTrajectory true;
+  residualLogEvery      1;
+  residualLogFile       "postProcessing/cudaPCG/residual.csv";
+  colourStatsFile       "postProcessing/cudaPCG/colour_stats.csv";
+  ```
+
+## Pipelined CG & CUDA Graph (2025-10-12)
+- Runtime switches added to the solver dictionary:
+  - `usePipelinedCG` toggles the Chronopoulos–Gear style update (`p = z + β(p - αAp)`), reducing redundant vector operations per iteration.
+  - `useCudaGraph` plus optional `cudaGraphWarmup` records the steady-state `cusparseSpMV` into a CUDA Graph after the warm-up stage and replays it on subsequent iterations via a dedicated non-blocking stream.
+- `bin/gpu_colour_sweep.sh` now records PCG iteration counts, final residuals, and Execution/Clock time for each case. Artefacts for the pipelined smoke test sit under `run/logs/pitzDaily_gpu_colour_pipelined_smoke_20251012-183303/`.
+- Observation: on pitzDaily the pipelined+graph path increases parity drift slightly (rel L2(Ux)≈3.3e-5 vs 1.36e-5) and is slower (~245 s vs 235 s). Keep it behind the runtime flag until further tuning, but the infrastructure is in place for Step 2 experiments.
+
 These changes keep the CPU code untouched and establish the parallel `_gpu` scaffolding described in the acceleration plan.

--- a/docs/gpu-notes.md
+++ b/docs/gpu-notes.md
@@ -1,0 +1,20 @@
+# GPU Acceleration Notes
+
+## Current Baseline
+- Solver: `pimpleFoam` with `cudaPCG` (diagonal preconditioner).
+- Validation case: `pitzDaily_gpu_phase1`.
+- Runtime: ~120 s on GPU after removing per-iteration host/device synchronisation inside the CG loop (CPU reference ~35 s).
+- Average pressure iterations: ~180 per time step (preconditioner still diagonal).
+
+## Infrastructure Added (2025-10-10)
+- `applications/solvers/incompressible/pimpleFoamGPU` – build target for GPU-specific solver experiments (mirrors the CPU solver for now).
+- `src/gpu/fields/gpuField` – initial placeholder library for GPU field handles.
+- `cudaPCG` optional dictionary flag `reportGpuStats` to print diagonal ranges, helping us pick safe regularisation factors when we add device-side preconditioners.
+- `cudaPCG` now keeps residuals/dots on the device (no vector-size copies each iteration), giving the ~2× runtime reduction above.
+
+## Next Focus Areas
+1. Implement fully device-resident preconditioning (e.g. ILU/IC with modern cuSPARSE SpSV routines). Initial attempts via the deprecated CSRsv2 path are blocked by the current CUDA toolkit.
+2. Keep field data on the GPU throughout the PIMPLE loop (remove remaining host copies).
+3. Move discretisation kernels into the `_gpu` tree outlined in `~/Downloads/acc_plan.md`.
+
+These changes keep the CPU code untouched and establish the parallel `_gpu` scaffolding described in the acceleration plan.

--- a/docs/gpu-pimple-plan-20251013.md
+++ b/docs/gpu-pimple-plan-20251013.md
@@ -63,4 +63,5 @@ This doc will track deviations and updates as the GPU PIMPLE loop matures.
 - Smoke test: run `pimpleFoamGPU` on `pitzDaily` twice (with and without `useGpuFieldOps`) and diff the final `phi`.
 - Automated harness: `run/scripts/run_gpu_parity.sh` performs the twin runs and reports mismatches (diff on `phi` & `U`).
 - Performance sweep: `run/scripts/benchmark_gpu_speed.sh` rebuilds baseline CPU/GPU cases and prints wall-clock and computed speedup.
+- Timing CSVs: enabling `PIMPLE.logGpuFieldOps` now records per-kernel milliseconds under `postProcessing/gpuFieldOps/<time>/stats.csv`.
 - Once more kernels land, extend the existing `run/scripts/run_gpu_trial.sh` harness to pass `useGpuFieldOps true` via an overlay `fvSolution` dictionary and compare against the CPU reference (`relative L2(Ux) ≤ 1e-2` gate).

--- a/docs/gpu-pimple-plan-20251013.md
+++ b/docs/gpu-pimple-plan-20251013.md
@@ -1,0 +1,66 @@
+# GPU PIMPLE Loop – Device Residency Plan
+
+## Objectives
+
+- Keep primary volume and surface fields (`volScalarField`, `volVectorField`, `surfaceScalarField`) resident on the GPU whenever the GPU path is enabled.
+- Provide an opt-in path that leaves the CPU code untouchhed when the GPU backend is disabled or unavailable.
+- Supply explicit host↔device synchronisation hooks so that we can port PIMPLE building blocks (ddt, div, laplacian, turbulence corrector, Courant logic) incrementally.
+
+## Design Highlights
+
+1. **Device Field Wrappers**
+   - Introduce lightweight `Foam::gpu::DeviceField<Type>` wrappers that own a CUDA buffer (`cudaMalloc/cudaFree`) and track dirty flags (`hostDirty`, `deviceDirty`).
+   - The wrapper is non-intrusive: it references an existing `GeometricField` (or `Field`) and mirrors the internal-field storage when asked.
+   - Synchronisation is explicit:
+     - `syncHostToDevice(...)` copies the current internal field to the device buffer.
+     - `syncDeviceToHost(...)` copies the device buffer back to the host field.
+   - When CUDA support is not compiled in (`FOAM_USE_CUDA` off), the class degenerates to a stub that compiles away.
+
+2. **Field Registry**
+   - A `Foam::gpu::FieldRegistry` keyed by address of the owning `GeometricField` ensures a single device buffer per field.
+   - Registration is explicit (from the solver) to avoid touching the core `GeometricField` constructors/destructors.
+   - Registry lifetime is tied to the `objectRegistry` via `MeshObject`, so buffers get released when the mesh/solver finishes.
+
+3. **Stream-aware Launch Context**
+   - A per-solver launch context stores the selected device, CUDA stream, and error-handling helpers (shared with `cudaPCG` in future cleanup).
+   - All kernels launched through helper functions that take the `launchContext` to manage error propagation and to keep a consistent stream policy.
+
+4. **Initial Kernel Scope**
+   - Start with kernels that operate purely on internal fields (no face coupling) to bring up the data path:
+     - `assign`: copy / scale / axpy style kernels.
+     - `Field-norm` reductions, used by Courant number logic and convergence monitors.
+   - Extend to face-coupled kernels (e.g. divergence, laplacian) once the field residency plumbing is validated.
+
+5. **Solver Integration**
+   - `pimpleFoamGPU` will:
+     - Detect GPU availability (`Foam::gpu::isEnabled()`).
+     - Register the primary fields with the registry after `createFields.H`.
+     - Swap discrete operator calls (e.g. `fvm::ddt`) with GPU-aware helpers that default to the existing CPU implementation when the GPU backend isn’t ready.
+   - Host-side fallbacks remain 1:1 with the upstream solver to preserve CPU behaviour.
+
+## Incremental Roll-out
+
+1. Implement the DeviceField + Registry infrastructure.
+2. Provide host↔device sync for `U`, `p`, `phi`, `Uf`, turbulence fields.
+3. Port algebraic vector operations (scale, axpy) and reductions (dot, norm) to the GPU.
+4. Replace PIMPLE building blocks with GPU kernels one by one, validating against the CPU reference after each major milestone.
+
+This doc will track deviations and updates as the GPU PIMPLE loop matures.
+
+## Current Prototypes
+
+- `fvSolution` toggle `PIMPLE.useGpuFieldOps` enables the first device-side operation:
+  - Final non-orthogonal update of `phi` executes as a CUDA kernel (`phi = phiHbyA - flux`).
+  - Falls back to CPU automatically and logs a warning if the kernel or data sync fails.
+- The velocity corrector now has a CUDA path (`U = HbyA - rAtU*grad(p)`), reusing the same residency plumbing and reporting kernel timing when `PIMPLE.logGpuFieldOps true`.
+- Device residency is established for `U`, `p`, and `phi` immediately after `createFields.H`. Transient working fields use scoped device buffers to avoid stale registry entries.
+
+## Verification Notes
+
+- Build targets:
+  - `wmake libso src/gpuInfrastructure`
+  - `wmake applications/solvers/incompressible/pimpleFoamGPU`
+- Smoke test: run `pimpleFoamGPU` on `pitzDaily` twice (with and without `useGpuFieldOps`) and diff the final `phi`.
+- Automated harness: `run/scripts/run_gpu_parity.sh` performs the twin runs and reports mismatches (diff on `phi` & `U`).
+- Performance sweep: `run/scripts/benchmark_gpu_speed.sh` rebuilds baseline CPU/GPU cases and prints wall-clock and computed speedup.
+- Once more kernels land, extend the existing `run/scripts/run_gpu_trial.sh` harness to pass `useGpuFieldOps true` via an overlay `fvSolution` dictionary and compare against the CPU reference (`relative L2(Ux) ≤ 1e-2` gate).

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -42,9 +42,9 @@ export WM_PROJECT_VERSION=10
 #
 # Please set to the appropriate path if the default is not correct.
 #
-[ "$BASH" -o "$ZSH_NAME" ] && \
-#export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/../.. && pwd -P) || \
-export FOAM_INST_DIR=/opt
+[ "$BASH" -o "${ZSH_NAME:-}" ] && \
+export FOAM_INST_DIR=$(cd $(dirname ${BASH_SOURCE:-$0})/.. && pwd -P) || \
+export FOAM_INST_DIR=$(cd $(dirname $0)/.. && pwd -P)
 # export FOAM_INST_DIR=~$WM_PROJECT
 # export FOAM_INST_DIR=/opt/$WM_PROJECT
 # export FOAM_INST_DIR=/usr/local/$WM_PROJECT
@@ -111,17 +111,7 @@ foamOldDirs="$WM_PROJECT_DIR $WM_THIRD_PARTY_DIR \
 # Location of installation
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 export WM_PROJECT_INST_DIR=$FOAM_INST_DIR
-export WM_PROJECT_DIR=$WM_PROJECT_INST_DIR/openfoam10
-
-if [ -d "$WM_PROJECT_DIR" ]
-then
-    WM_PROJECT_DIR_REAL=$(cd $WM_PROJECT_DIR && pwd -P)
-    if [ -d "$WM_PROJECT_DIR_REAL" -a -e "$WM_PROJECT_DIR_REAL/etc/bashrc" ]
-    then
-        export WM_PROJECT_DIR=$WM_PROJECT_INST_DIR/openfoam10
-    fi
-    unset WM_PROJECT_DIR_REAL
-fi
+export WM_PROJECT_DIR=$WM_PROJECT_INST_DIR
 
 # Location of third-party software
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/run/scripts/benchmark_gpu_speed.sh
+++ b/run/scripts/benchmark_gpu_speed.sh
@@ -34,9 +34,11 @@ foamDictionary -entry "PIMPLE/useGpuFieldOps" -set true "${GPU_CASE}/system/fvSo
 foamDictionary -entry "PIMPLE/logGpuFieldOps" -set false "${GPU_CASE}/system/fvSolution" >/dev/null
 foamDictionary -entry "PIMPLE/logGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null 2>&1 || true
 foamDictionary -entry "PIMPLE/useGpuCudaGraphs" -set true "${GPU_CASE}/system/fvSolution" >/dev/null 2>&1 || true
-
 # Default to enabling CUDA Graphs unless caller overrides.
 export FOAM_GPU_ENABLE_CUDA_GRAPHS="${FOAM_GPU_ENABLE_CUDA_GRAPHS:-1}"
+
+# Watchdog timeout for GPU runs (seconds)
+GPU_TRIAL_TIMEOUT_SEC=${GPU_TRIAL_TIMEOUT_SEC:-600}
 
 run_case() {
     local solver=$1
@@ -44,7 +46,14 @@ run_case() {
     (
         cd "${caseDir}"
         blockMesh -dict "$FOAM_TUTORIALS/resources/blockMesh/pitzDaily" > log.blockMesh
-        ${solver} > log.${solver}
+        if [[ "${solver}" == "${GPU_SOLVER}" ]]; then
+            timeout -k 10 ${GPU_TRIAL_TIMEOUT_SEC}s ${solver} > log.${solver} || {
+                echo "GPU run exceeded ${GPU_TRIAL_TIMEOUT_SEC}s or failed; see log.${solver}" >&2
+                exit 124
+            }
+        else
+            ${solver} > log.${solver}
+        fi
     )
 }
 

--- a/run/scripts/benchmark_gpu_speed.sh
+++ b/run/scripts/benchmark_gpu_speed.sh
@@ -30,8 +30,13 @@ cp -r "${BASE_CASE}" "${GPU_CASE}"
 
 # GPU case: enable GPU switches
 foamDictionary -entry application -set ${GPU_SOLVER} "${GPU_CASE}/system/controlDict" >/dev/null
-foamDictionary -entry "PIMPLE.useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
-foamDictionary -entry "PIMPLE.logGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/logGpuFieldOps" -set false "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/logGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null 2>&1 || true
+foamDictionary -entry "PIMPLE/useGpuCudaGraphs" -set true "${GPU_CASE}/system/fvSolution" >/dev/null 2>&1 || true
+
+# Default to enabling CUDA Graphs unless caller overrides.
+export FOAM_GPU_ENABLE_CUDA_GRAPHS="${FOAM_GPU_ENABLE_CUDA_GRAPHS:-1}"
 
 run_case() {
     local solver=$1
@@ -65,4 +70,26 @@ gpu = float(sys.argv[2])
 speedup = cpu / gpu if gpu else float('inf')
 print(f"Speedup (CPU/GPU): {speedup:.3f}x")
 PYCODE
+fi
+
+REPORT_DIR="${REPO_ROOT}/run/benchmark_results/${CASE_NAME}"
+rm -rf "${REPORT_DIR}"
+mkdir -p "${REPORT_DIR}"
+
+cp "${CPU_CASE}/log.${CPU_SOLVER}" "${REPORT_DIR}/log.cpu"
+cp "${GPU_CASE}/log.${GPU_SOLVER}" "${REPORT_DIR}/log.gpu"
+
+if [[ -d "${GPU_CASE}/postProcessing/gpuFieldOps" ]]; then
+    cp -r "${GPU_CASE}/postProcessing/gpuFieldOps" "${REPORT_DIR}/gpuFieldOps"
+    SUMMARY_FILE="${REPORT_DIR}/gpuFieldOps/summary.csv"
+    if [[ -f "${SUMMARY_FILE}" ]]; then
+        total_ms=$(awk -F',' 'NR>1 {sum+=$4} END {printf "%.6f", sum+0}' "${SUMMARY_FILE}")
+        fallback_samples=$(awk -F',' 'NR>1 && $2 ~ /_cpu$/ {sum+=$3} END {printf "%d", sum+0}' "${SUMMARY_FILE}")
+        {
+            echo "cpuExecutionTime=${CPU_TIME}"
+            echo "gpuExecutionTime=${GPU_TIME}"
+            echo "gpuKernelTotalMilliseconds=${total_ms}"
+            echo "gpuFallbackSamples=${fallback_samples}"
+        } > "${REPORT_DIR}/summary.txt"
+    fi
 fi

--- a/run/scripts/benchmark_gpu_speed.sh
+++ b/run/scripts/benchmark_gpu_speed.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+CASE_NAME=${1:-pitzDaily_gpu_colour}
+BASE_CASE="${REPO_ROOT}/tutorials/incompressible/pimpleFoam/RAS/pitzDaily"
+
+if [[ ! -d "${BASE_CASE}" ]]; then
+    echo "Base tutorial not found at ${BASE_CASE}" >&2
+    exit 1
+fi
+
+if [[ -z "${WM_PROJECT_DIR:-}" ]]; then
+    . "${REPO_ROOT}/etc/bashrc"
+fi
+
+CPU_SOLVER="pimpleFoam"
+GPU_SOLVER="pimpleFoamGPU"
+
+CPU_CASE="${REPO_ROOT}/run/${CASE_NAME}_cpu_baseline"
+GPU_CASE="${REPO_ROOT}/run/${CASE_NAME}_gpu"
+
+rm -rf "${CPU_CASE}" "${GPU_CASE}"
+cp -r "${BASE_CASE}" "${CPU_CASE}"
+cp -r "${BASE_CASE}" "${GPU_CASE}"
+
+# CPU baseline uses stock solver.
+
+# GPU case: enable GPU switches
+foamDictionary -entry application -set ${GPU_SOLVER} "${GPU_CASE}/system/controlDict" >/dev/null
+foamDictionary -entry "PIMPLE.useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE.logGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+
+run_case() {
+    local solver=$1
+    local caseDir=$2
+    (
+        cd "${caseDir}"
+        blockMesh -dict "$FOAM_TUTORIALS/resources/blockMesh/pitzDaily" > log.blockMesh
+        ${solver} > log.${solver}
+    )
+}
+
+run_case "${CPU_SOLVER}" "${CPU_CASE}"
+run_case "${GPU_SOLVER}" "${GPU_CASE}"
+
+extract_time() {
+    local logFile=$1
+    awk '/ExecutionTime/ {time=$3} END {print time}' "${logFile}"
+}
+
+CPU_TIME=$(extract_time "${CPU_CASE}/log.${CPU_SOLVER}")
+GPU_TIME=$(extract_time "${GPU_CASE}/log.${GPU_SOLVER}")
+
+echo "CPU ExecutionTime: ${CPU_TIME} s"
+echo "GPU ExecutionTime: ${GPU_TIME} s"
+
+if [[ -n "${GPU_TIME}" && -n "${CPU_TIME}" ]]; then
+    python3 - "$CPU_TIME" "$GPU_TIME" <<'PYCODE'
+import sys
+cpu = float(sys.argv[1])
+gpu = float(sys.argv[2])
+speedup = cpu / gpu if gpu else float('inf')
+print(f"Speedup (CPU/GPU): {speedup:.3f}x")
+PYCODE
+fi

--- a/run/scripts/run_gpu_parity.sh
+++ b/run/scripts/run_gpu_parity.sh
@@ -30,8 +30,13 @@ cp -r "${BASE_CASE}" "${GPU_CASE}"
 
 foamDictionary -entry application -set pimpleFoamGPU "${CPU_CASE}/system/controlDict" >/dev/null
 foamDictionary -entry application -set pimpleFoamGPU "${GPU_CASE}/system/controlDict" >/dev/null
-foamDictionary -entry "PIMPLE.useGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
-foamDictionary -entry "PIMPLE.useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/useGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/logGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/logGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+FORCE_CPU_PRESSURE=${FORCE_CPU_PRESSURE:-false}
+foamDictionary -entry "PIMPLE/forceCpuPressureCorrector" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE/forceCpuPressureCorrector" -set "${FORCE_CPU_PRESSURE}" "${GPU_CASE}/system/fvSolution" >/dev/null
 
 set_turbulence_gpu_flag()
 {
@@ -74,6 +79,17 @@ run_case() {
 run_case "${CPU_CASE}"
 run_case "${GPU_CASE}"
 
+RESULT_BASE="${REPO_ROOT}/run/parity_results/${CASE_NAME}"
+rm -rf "${RESULT_BASE}"
+mkdir -p "${RESULT_BASE}"
+
+cp "${CPU_CASE}/log.pimpleFoamGPU" "${RESULT_BASE}/log.cpu"
+cp "${GPU_CASE}/log.pimpleFoamGPU" "${RESULT_BASE}/log.gpu"
+
+if [[ -d "${GPU_CASE}/postProcessing/gpuFieldOps" ]]; then
+    cp -r "${GPU_CASE}/postProcessing/gpuFieldOps" "${RESULT_BASE}/gpuFieldOps"
+fi
+
 LATEST_TIME=$(foamListTimes -case "${CPU_CASE}" -latestTime)
 
 CPU_PHI="${CPU_CASE}/${LATEST_TIME}/phi"
@@ -81,14 +97,169 @@ GPU_PHI="${GPU_CASE}/${LATEST_TIME}/phi"
 CPU_U="${CPU_CASE}/${LATEST_TIME}/U"
 GPU_U="${GPU_CASE}/${LATEST_TIME}/U"
 
-if ! diff -q "${CPU_PHI}" "${GPU_PHI}" >/dev/null; then
-    echo "Mismatch detected in phi between CPU and GPU runs." >&2
-    exit 2
-fi
+TOLERANCE=${3:-0}
 
-if ! diff -q "${CPU_U}" "${GPU_U}" >/dev/null; then
-    echo "Mismatch detected in U between CPU and GPU runs." >&2
-    exit 3
+python3 - "$CPU_PHI" "$GPU_PHI" "$TOLERANCE" <<'PYCODE' || exit 2
+import math
+import sys
+
+def read_field(path):
+    with open(path) as fh:
+        lines = fh.readlines()
+    idx = 0
+    n = len(lines)
+    data = []
+    while idx < n:
+        line = lines[idx].strip()
+        if line.startswith("internalField"):
+            if "nonuniform" in line:
+                idx += 1
+                count = int(lines[idx].strip())
+                idx += 1
+                while idx < n and len(data) < count:
+                    token = lines[idx].strip()
+                    idx += 1
+                    if not token or token in ("(", ")", ");"):
+                        continue
+                    token = token.replace(";", "")
+                    if token.startswith("("):
+                        vals = [float(x) for x in token.strip("()").split()]
+                    else:
+                        vals = [float(token)]
+                    data.append(vals)
+                return data
+            elif "uniform" in line:
+                value = line.split("uniform", 1)[1].split(";")[0].strip()
+                if value.startswith("("):
+                    vals = [float(x) for x in value.strip("()").split()]
+                else:
+                    vals = [float(value)]
+                data.append(vals)
+                return data
+        idx += 1
+    raise RuntimeError(f"No internalField found in {path}")
+
+def norm2(entry):
+    return sum(value*value for value in entry)
+
+ref = read_field(sys.argv[1])
+test = read_field(sys.argv[2])
+
+if len(ref) != len(test):
+    print(f"Size mismatch: {len(ref)} vs {len(test)}", file=sys.stderr)
+    sys.exit(1)
+
+sq_diff = 0.0
+sq_ref = 0.0
+for a, b in zip(ref, test):
+    if len(a) != len(b):
+        print("Entry size mismatch", file=sys.stderr)
+        sys.exit(1)
+    diff = [ai - bi for ai, bi in zip(a, b)]
+    sq_diff += norm2(diff)
+    sq_ref += norm2(a)
+
+err = math.sqrt(sq_diff)
+den = math.sqrt(sq_ref)
+if den < 1e-30:
+    den = 1.0
+rel = err/den
+print(f"phi relative L2 error: {rel:.6e}")
+if rel > float(sys.argv[3]):
+    sys.exit(1)
+PYCODE
+
+python3 - "$CPU_U" "$GPU_U" "$TOLERANCE" <<'PYCODE' || exit 3
+import math
+import sys
+
+def read_field(path):
+    with open(path) as fh:
+        lines = fh.readlines()
+    idx = 0
+    n = len(lines)
+    data = []
+    while idx < n:
+        line = lines[idx].strip()
+        if line.startswith("internalField"):
+            if "nonuniform" in line:
+                idx += 1
+                count = int(lines[idx].strip())
+                idx += 1
+                while idx < n and len(data) < count:
+                    token = lines[idx].strip()
+                    idx += 1
+                    if not token or token in ("(", ")", ");"):
+                        continue
+                    token = token.replace(";", "")
+                    if token.startswith("("):
+                        vals = [float(x) for x in token.strip("()").split()]
+                    else:
+                        vals = [float(token)]
+                    data.append(vals)
+                return data
+            elif "uniform" in line:
+                value = line.split("uniform", 1)[1].split(";")[0].strip()
+                if value.startswith("("):
+                    vals = [float(x) for x in value.strip("()").split()]
+                else:
+                    vals = [float(value)]
+                data.append(vals)
+                return data
+        idx += 1
+    raise RuntimeError(f"No internalField found in {path}")
+
+def norm2(entry):
+    return sum(value*value for value in entry)
+
+ref = read_field(sys.argv[1])
+test = read_field(sys.argv[2])
+
+if len(ref) != len(test):
+    print(f"Size mismatch: {len(ref)} vs {len(test)}", file=sys.stderr)
+    sys.exit(1)
+
+sq_diff = 0.0
+sq_ref = 0.0
+for a, b in zip(ref, test):
+    if len(a) != len(b):
+        print("Entry size mismatch", file=sys.stderr)
+        sys.exit(1)
+    diff = [ai - bi for ai, bi in zip(a, b)]
+    sq_diff += norm2(diff)
+    sq_ref += norm2(a)
+
+err = math.sqrt(sq_diff)
+den = math.sqrt(sq_ref)
+if den < 1e-30:
+    den = 1.0
+rel = err/den
+print(f"U relative L2 error: {rel:.6e}")
+if rel > float(sys.argv[3]):
+    sys.exit(1)
+PYCODE
+
+RESULT_BASE="${REPO_ROOT}/run/parity_results/${CASE_NAME}"
+rm -rf "${RESULT_BASE}"
+mkdir -p "${RESULT_BASE}"
+
+cp "${CPU_CASE}/log.pimpleFoamGPU" "${RESULT_BASE}/log.cpu"
+cp "${GPU_CASE}/log.pimpleFoamGPU" "${RESULT_BASE}/log.gpu"
+
+if [[ -d "${RESULT_BASE}/gpuFieldOps" ]]; then
+    SUMMARY_FILE="${RESULT_BASE}/gpuFieldOps/summary.csv"
+    if [[ -f "${SUMMARY_FILE}" ]]; then
+        total_ms=$(awk -F',' 'NR>1 {sum+=$4} END {printf "%.6f", sum+0}' "${SUMMARY_FILE}")
+        fallback_samples=$(awk -F',' 'NR>1 && $2 ~ /_cpu$/ {sum+=$3} END {printf "%d", sum+0}' "${SUMMARY_FILE}")
+        {
+            echo "gpuKernelTotalMilliseconds=${total_ms}"
+            echo "gpuFallbackSamples=${fallback_samples}"
+        } > "${RESULT_BASE}/summary.txt"
+        echo "GPU kernel total (ms): ${total_ms}"
+        if [[ "${fallback_samples}" -gt 0 ]]; then
+            echo "GPU CPU fallbacks detected: ${fallback_samples}" >&2
+        fi
+    fi
 fi
 
 echo "GPU parity check passed at time ${LATEST_TIME}."

--- a/run/scripts/run_gpu_parity.sh
+++ b/run/scripts/run_gpu_parity.sh
@@ -67,12 +67,18 @@ set_turbulence_gpu_flag()
 set_turbulence_gpu_flag "${CPU_CASE}" false
 set_turbulence_gpu_flag "${GPU_CASE}" true
 
+# Watchdog timeout for GPU parity run (seconds)
+GPU_TRIAL_TIMEOUT_SEC=${GPU_TRIAL_TIMEOUT_SEC:-600}
+
 run_case() {
     local caseDir=$1
     (
         cd "${caseDir}"
         blockMesh -dict "$FOAM_TUTORIALS/resources/blockMesh/pitzDaily" > log.blockMesh
-        pimpleFoamGPU > log.pimpleFoamGPU
+        timeout -k 10 ${GPU_TRIAL_TIMEOUT_SEC}s pimpleFoamGPU > log.pimpleFoamGPU || {
+            echo "Parity GPU run exceeded ${GPU_TRIAL_TIMEOUT_SEC}s or failed; see log.pimpleFoamGPU" >&2
+            exit 124
+        }
     )
 }
 

--- a/run/scripts/run_gpu_parity.sh
+++ b/run/scripts/run_gpu_parity.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -eo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+usage() {
+    echo "Usage: $(basename "$0") [caseName]" >&2
+    echo "Defaults to pitzDaily." >&2
+}
+
+CASE_NAME=${1:-pitzDaily}
+BASE_CASE="${REPO_ROOT}/tutorials/incompressible/pimpleFoam/RAS/pitzDaily"
+
+if [[ ! -d "${BASE_CASE}" ]]; then
+    echo "Base tutorial not found at ${BASE_CASE}" >&2
+    exit 1
+fi
+
+if [[ -z "${WM_PROJECT_DIR:-}" ]]; then
+    . "${REPO_ROOT}/etc/bashrc"
+fi
+
+CPU_CASE="${REPO_ROOT}/run/${CASE_NAME}_cpu"
+GPU_CASE="${REPO_ROOT}/run/${CASE_NAME}_gpu"
+
+rm -rf "${CPU_CASE}" "${GPU_CASE}"
+cp -r "${BASE_CASE}" "${CPU_CASE}"
+cp -r "${BASE_CASE}" "${GPU_CASE}"
+
+foamDictionary -entry application -set pimpleFoamGPU "${CPU_CASE}/system/controlDict" >/dev/null
+foamDictionary -entry application -set pimpleFoamGPU "${GPU_CASE}/system/controlDict" >/dev/null
+foamDictionary -entry "PIMPLE.useGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
+foamDictionary -entry "PIMPLE.useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
+
+run_case() {
+    local caseDir=$1
+    (
+        cd "${caseDir}"
+        blockMesh -dict "$FOAM_TUTORIALS/resources/blockMesh/pitzDaily" > log.blockMesh
+        pimpleFoamGPU > log.pimpleFoamGPU
+    )
+}
+
+run_case "${CPU_CASE}"
+run_case "${GPU_CASE}"
+
+LATEST_TIME=$(foamListTimes -case "${CPU_CASE}" -latestTime)
+
+CPU_PHI="${CPU_CASE}/${LATEST_TIME}/phi"
+GPU_PHI="${GPU_CASE}/${LATEST_TIME}/phi"
+CPU_U="${CPU_CASE}/${LATEST_TIME}/U"
+GPU_U="${GPU_CASE}/${LATEST_TIME}/U"
+
+if ! diff -q "${CPU_PHI}" "${GPU_PHI}" >/dev/null; then
+    echo "Mismatch detected in phi between CPU and GPU runs." >&2
+    exit 2
+fi
+
+if ! diff -q "${CPU_U}" "${GPU_U}" >/dev/null; then
+    echo "Mismatch detected in U between CPU and GPU runs." >&2
+    exit 3
+fi
+
+echo "GPU parity check passed at time ${LATEST_TIME}."

--- a/run/scripts/run_gpu_parity.sh
+++ b/run/scripts/run_gpu_parity.sh
@@ -33,6 +33,35 @@ foamDictionary -entry application -set pimpleFoamGPU "${GPU_CASE}/system/control
 foamDictionary -entry "PIMPLE.useGpuFieldOps" -set false "${CPU_CASE}/system/fvSolution" >/dev/null
 foamDictionary -entry "PIMPLE.useGpuFieldOps" -set true "${GPU_CASE}/system/fvSolution" >/dev/null
 
+set_turbulence_gpu_flag()
+{
+    local caseDir=$1
+    local value=$2
+    local dictPath="${caseDir}/constant/RASProperties"
+    if [[ -f "${dictPath}" ]]; then
+        for entry in \
+            "RASModelCoeffs.useGPU" \
+            "kEpsilonCoeffs.useGPU" \
+            "coeffs.useGPU"
+        do
+            foamDictionary -entry "${entry}" -set "${value}" "${dictPath}" >/dev/null 2>&1 || true
+        done
+    fi
+
+    dictPath="${caseDir}/constant/momentumTransport"
+    if [[ -f "${dictPath}" ]]; then
+        for entry in \
+            "RAS.coeffs.useGPU" \
+            "RAS.kEpsilonCoeffs.useGPU"
+        do
+            foamDictionary -entry "${entry}" -set "${value}" "${dictPath}" >/dev/null 2>&1 || true
+        done
+    fi
+}
+
+set_turbulence_gpu_flag "${CPU_CASE}" false
+set_turbulence_gpu_flag "${GPU_CASE}" true
+
 run_case() {
     local caseDir=$1
     (

--- a/scripts/analyse_colour_summary.py
+++ b/scripts/analyse_colour_summary.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+from pathlib import Path
+from statistics import mean, pstdev
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute statistics from colour summary CSV.")
+    parser.add_argument("summary", help="Path to summary.csv")
+    parser.add_argument("--group-by-floor", action="store_true", help="Group statistics by diagonal floor as well")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summary_path = Path(args.summary)
+    if not summary_path.is_file():
+        print(f"Missing summary file: {summary_path}")
+        return 2
+
+    with summary_path.open('r', encoding='utf-8') as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+
+    key_fields = ['omega', 'backwardOmega']
+    if args.group_by_floor:
+        key_fields.append('diagFloor')
+
+    groups = {}
+    for row in rows:
+        key = tuple(row[field] for field in key_fields)
+        groups.setdefault(key, []).append(row)
+
+    print("key,avgIter,stdIter,minIter,maxIter,avgTime,avgRelL2")
+    for key, items in sorted(groups.items()):
+        iters = [float(item['pcgIterations']) for item in items if item['pcgIterations']]
+        times = [float(item['executionTime']) for item in items if item['executionTime']]
+        rels = [float(item['relL2_Ux']) for item in items if item['relL2_Ux']]
+        avg_iter = mean(iters) if iters else 0.0
+        std_iter = pstdev(iters) if len(iters) > 1 else 0.0
+        min_iter = min(iters) if iters else 0.0
+        max_iter = max(iters) if iters else 0.0
+        avg_time = mean(times) if times else 0.0
+        avg_rel = mean(rels) if rels else 0.0
+        key_str = ";".join(key)
+        print(f"{key_str},{avg_iter:.2f},{std_iter:.2f},{min_iter:.0f},{max_iter:.0f},{avg_time:.2f},{avg_rel:.3e}")
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/run_colour_grid.py
+++ b/scripts/run_colour_grid.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from itertools import product
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run colour sweeps over a parameter grid")
+    parser.add_argument("--template", default="pitzDaily_clean")
+    parser.add_argument("--cpu-case", default="pitzDaily_cpu")
+    parser.add_argument("--omegas", default="0.5,0.55,0.6,0.65,0.7")
+    parser.add_argument("--backs", default="0.7,0.75,0.8,0.85,0.9")
+    parser.add_argument("--floors", default="1e-12,5e-12")
+    parser.add_argument("--run-root", default="/home/xiaozhou/OpenFOAM/xiaozhou-10/run")
+    parser.add_argument("--prefix", default="pitzDaily_gpu_colour_grid")
+    parser.add_argument("--summary-check", action="store_true")
+    parser.add_argument("--max-rel", default="1e-3")
+    parser.add_argument("--max-iter", default="900")
+    parser.add_argument("--max-time", default="260")
+    args = parser.parse_args()
+
+    omegas = [float(x) for x in args.omegas.split(',')]
+    backs = [float(x) for x in args.backs.split(',')]
+    floors = args.floors.split(',')
+
+    combos = [
+        (o, b, f)
+        for o in omegas
+        for b in backs
+        for f in floors
+        if b >= o
+    ]
+
+    for omega, back, floor in combos:
+        case_prefix = f"{args.prefix}_o{omega:.2f}_b{back:.2f}_d{floor.replace('-', 'm')}"
+        cmd = [
+            "bin/gpu_colour_sweep.sh",
+            "--run-root", args.run_root,
+            "--template", args.template,
+            "--cpu-case", args.cpu_case,
+            "--prefix", case_prefix,
+            "--omegas", f"{omega}",
+            "--backward", f"{back}",
+            "--floors", floor,
+            "--log-iter"
+        ]
+        if args.summary_check:
+            cmd += [
+                "--summary-check",
+                "--max-rel", args.max_rel,
+                "--max-iter", args.max_iter,
+                "--max-time", args.max_time
+            ]
+        print("Running:", " ".join(cmd))
+        result = subprocess.run(cmd, check=True)
+        if result.returncode != 0:
+            sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/MomentumTransportModels/incompressible/Make/options
+++ b/src/MomentumTransportModels/incompressible/Make/options
@@ -3,14 +3,17 @@ EXE_INC = \
     -I$(LIB_SRC)/physicalProperties/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/gpuInfrastructure/lnInclude \
     -I/usr/local/cuda/include \
     -DFOAM_USE_CUDA
 
 LIB_LIBS = \
+    -L$(FOAM_USER_LIBBIN) \
     -lphysicalProperties \
     -lmomentumTransportModels \
     -lfiniteVolume \
     -lmeshTools \
+    -lgpuInfrastructure \
     -L/usr/local/cuda/lib64 \
     -lcuda \
     -lnvrtc

--- a/src/MomentumTransportModels/momentumTransportModels/RAS/kEpsilon/kEpsilon.C
+++ b/src/MomentumTransportModels/momentumTransportModels/RAS/kEpsilon/kEpsilon.C
@@ -28,18 +28,14 @@ License
 #include "fvConstraints.H"
 #include "bound.H"
 #include "Switch.H"
+#include "GpuContext.H"
+#include "DeviceField.H"
+#include "FieldOps.H"
 
 #include <algorithm>
 #include <cctype>
 #include <sstream>
 #include <string>
-
-#ifdef FOAM_USE_CUDA
-#include <cuda.h>
-#include <nvrtc.h>
-#include <mutex>
-#include <vector>
-#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -48,436 +44,11 @@ namespace Foam
 namespace RASModels
 {
 
-#ifdef FOAM_USE_CUDA
-namespace
-{
-
-inline std::string cudaErrorMessage(const char* prefix, const CUresult code)
-{
-    const char* msg = nullptr;
-    cuGetErrorString(code, &msg);
-
-    std::ostringstream os;
-    os << prefix;
-    if (msg)
-    {
-        os << msg;
-    }
-    else
-    {
-        os << "unknown CUDA error";
-    }
-    os << " (" << static_cast<int>(code) << ')';
-    return os.str();
-}
-
-
-inline std::string nvrtcErrorMessage
-(
-    const char* prefix,
-    const nvrtcResult code
-)
-{
-    std::ostringstream os;
-    os << prefix << nvrtcGetErrorString(code) << " (" << static_cast<int>(code)
-       << ')';
-    return os.str();
-}
-
-
-class kEpsilonCudaBackend
-{
-    std::mutex mutex_;
-    bool contextInitialised_;
-    bool kernelReady_;
-    int deviceId_;
-    CUcontext context_;
-    CUmodule module_;
-    CUfunction correctNutKernel_;
-    bool usingPrimaryContext_;
-
-    void cleanupLocked()
-    {
-        if (module_)
-        {
-            cuModuleUnload(module_);
-            module_ = nullptr;
-        }
-
-        if (context_)
-        {
-            if (usingPrimaryContext_)
-            {
-                cuDevicePrimaryCtxRelease(deviceId_);
-            }
-            else
-            {
-                cuCtxDestroy(context_);
-            }
-            context_ = nullptr;
-        }
-
-        contextInitialised_ = false;
-        kernelReady_ = false;
-        deviceId_ = -1;
-        usingPrimaryContext_ = false;
-    }
-
-    bool compileKernel(const int deviceId, std::string& errorMessage)
-    {
-        CUdevice device;
-        CUresult status = cuDeviceGet(&device, deviceId);
-
-        if (status != CUDA_SUCCESS)
-        {
-            errorMessage = cudaErrorMessage("cuDeviceGet: ", status);
-            return false;
-        }
-
-        int major = 0;
-        int minor = 0;
-        status = cuDeviceComputeCapability(&major, &minor, device);
-
-        if (status != CUDA_SUCCESS)
-        {
-            errorMessage = cudaErrorMessage("cuDeviceComputeCapability: ", status);
-            return false;
-        }
-
-        std::ostringstream arch;
-        arch << "--gpu-architecture=compute_" << major << minor;
-
-        const std::string scalarName =
-            sizeof(scalar) == sizeof(float) ? "float" : "double";
-
-        std::ostringstream source;
-        source
-            << "extern \"C\" __global__ void correctNutKernel("
-            << scalarName << "* __restrict__ nut,"
-            << " const " << scalarName << "* __restrict__ k,"
-            << " const " << scalarName << "* __restrict__ epsilon,"
-            << ' ' << scalarName << " Cmu,"
-            << ' ' << scalarName << " kMin,"
-            << ' ' << scalarName << " epsilonMin,"
-            << " int n)\n"
-            << "{\n"
-            << "    int idx = blockIdx.x * blockDim.x + threadIdx.x;\n"
-            << "    if (idx < n)\n    {\n"
-            << "        " << scalarName << " kval = k[idx];\n"
-            << "        if (kval < kMin) kval = kMin;\n"
-            << "        " << scalarName << " eps = epsilon[idx];\n"
-            << "        if (eps < epsilonMin) eps = epsilonMin;\n"
-            << "        " << scalarName << " value = Cmu * kval * kval / eps;\n"
-            << "        nut[idx] = value;\n"
-            << "    }\n"
-            << "}\n";
-
-        nvrtcProgram prog;
-        nvrtcResult nvStatus = nvrtcCreateProgram
-        (
-            &prog,
-            source.str().c_str(),
-            "kEpsilonCorrectNut.cu",
-            0,
-            nullptr,
-            nullptr
-        );
-
-        if (nvStatus != NVRTC_SUCCESS)
-        {
-            errorMessage = nvrtcErrorMessage("nvrtcCreateProgram: ", nvStatus);
-            return false;
-        }
-
-        std::vector<std::string> optionStorage;
-        optionStorage.emplace_back("--std=c++14");
-        optionStorage.emplace_back("--fmad=false");
-        optionStorage.emplace_back(arch.str());
-
-        std::vector<const char*> options;
-        options.reserve(optionStorage.size());
-        for (const std::string& opt : optionStorage)
-        {
-            options.push_back(opt.c_str());
-        }
-
-        nvStatus = nvrtcCompileProgram(prog, options.size(), options.data());
-
-        if (nvStatus != NVRTC_SUCCESS)
-        {
-            size_t logSize = 0;
-            nvrtcGetProgramLogSize(prog, &logSize);
-            std::string log(logSize, '\0');
-            if (logSize > 1)
-            {
-                char* logPtr = log.empty() ? nullptr : &log[0];
-                if (logPtr)
-                {
-                    nvrtcGetProgramLog(prog, logPtr);
-                }
-            }
-            nvrtcDestroyProgram(&prog);
-
-            std::ostringstream os;
-            os << "nvrtcCompileProgram: " << nvrtcGetErrorString(nvStatus);
-            if (!log.empty())
-            {
-                os << '\n' << log;
-            }
-            errorMessage = os.str();
-            return false;
-        }
-
-        size_t ptxSize = 0;
-        nvrtcGetPTXSize(prog, &ptxSize);
-        std::string ptx(ptxSize, '\0');
-        if (ptxSize)
-        {
-            nvrtcGetPTX(prog, &ptx[0]);
-        }
-        nvrtcDestroyProgram(&prog);
-
-        status = cuModuleLoadDataEx(&module_, ptx.c_str(), 0, nullptr, nullptr);
-        if (status != CUDA_SUCCESS)
-        {
-            errorMessage = cudaErrorMessage("cuModuleLoadDataEx: ", status);
-            return false;
-        }
-
-        status = cuModuleGetFunction(&correctNutKernel_, module_, "correctNutKernel");
-        if (status != CUDA_SUCCESS)
-        {
-            errorMessage = cudaErrorMessage("cuModuleGetFunction: ", status);
-            return false;
-        }
-
-        kernelReady_ = true;
-        return true;
-    }
-
-public:
-
-    kEpsilonCudaBackend()
-    :
-        mutex_(),
-        contextInitialised_(false),
-        kernelReady_(false),
-        deviceId_(-1),
-        context_(nullptr),
-        module_(nullptr),
-        correctNutKernel_(nullptr),
-        usingPrimaryContext_(false)
-    {}
-
-    ~kEpsilonCudaBackend()
-    {
-        std::lock_guard<std::mutex> guard(mutex_);
-        cleanupLocked();
-    }
-
-    bool prepare(const int requestedDeviceId, std::string& message)
-    {
-        std::lock_guard<std::mutex> guard(mutex_);
-        message.clear();
-
-        if (kernelReady_ && contextInitialised_ && requestedDeviceId == deviceId_)
-        {
-            cuCtxSetCurrent(context_);
-            return true;
-        }
-
-        cleanupLocked();
-
-        CUresult status = cuInit(0);
-        if (status != CUDA_SUCCESS)
-        {
-            message = cudaErrorMessage("cuInit: ", status);
-            return false;
-        }
-
-        int deviceCount = 0;
-        status = cuDeviceGetCount(&deviceCount);
-        if (status != CUDA_SUCCESS)
-        {
-            message = cudaErrorMessage("cuDeviceGetCount: ", status);
-            return false;
-        }
-
-        if (deviceCount <= 0)
-        {
-            message = "No CUDA devices detected";
-            return false;
-        }
-
-        int selectedDevice = requestedDeviceId;
-        if (selectedDevice < 0 || selectedDevice >= deviceCount)
-        {
-            selectedDevice = ((selectedDevice % deviceCount) + deviceCount) % deviceCount;
-        }
-
-        CUdevice device;
-        status = cuDeviceGet(&device, selectedDevice);
-        if (status != CUDA_SUCCESS)
-        {
-            message = cudaErrorMessage("cuDeviceGet: ", status);
-            return false;
-        }
-
-        status = cuDevicePrimaryCtxRetain(&context_, device);
-        if (status != CUDA_SUCCESS)
-        {
-            message = cudaErrorMessage("cuDevicePrimaryCtxRetain: ", status);
-            return false;
-        }
-
-        usingPrimaryContext_ = true;
-
-        contextInitialised_ = true;
-        deviceId_ = selectedDevice;
-
-        cuCtxSetCurrent(context_);
-
-        if (!compileKernel(selectedDevice, message))
-        {
-            cleanupLocked();
-            return false;
-        }
-
-        return kernelReady_;
-    }
-
-    bool launchCorrectNut
-    (
-        scalar* nut,
-        const scalar* k,
-        const scalar* epsilon,
-        const label nCells,
-        const scalar Cmu,
-        const scalar kMin,
-        const scalar epsilonMin
-    )
-    {
-        std::lock_guard<std::mutex> guard(mutex_);
-
-        if (!kernelReady_ || !contextInitialised_)
-        {
-            return false;
-        }
-
-        cuCtxSetCurrent(context_);
-
-        const size_t bytes = nCells*sizeof(scalar);
-
-        CUdeviceptr dNut = 0;
-        CUdeviceptr dK = 0;
-        CUdeviceptr dEps = 0;
-
-        CUresult status = cuMemAlloc(&dNut, bytes);
-        if (status != CUDA_SUCCESS)
-        {
-            return false;
-        }
-
-        status = cuMemAlloc(&dK, bytes);
-        if (status != CUDA_SUCCESS)
-        {
-            cuMemFree(dNut);
-            return false;
-        }
-
-        status = cuMemAlloc(&dEps, bytes);
-        if (status != CUDA_SUCCESS)
-        {
-            cuMemFree(dNut);
-            cuMemFree(dK);
-            return false;
-        }
-
-        bool ok = true;
-
-        status = cuMemcpyHtoD(dK, k, bytes);
-        ok = ok && status == CUDA_SUCCESS;
-        status = cuMemcpyHtoD(dEps, epsilon, bytes);
-        ok = ok && status == CUDA_SUCCESS;
-
-        if (!ok)
-        {
-            cuMemFree(dNut);
-            cuMemFree(dK);
-            cuMemFree(dEps);
-            return false;
-        }
-
-        const int threadsPerBlock = 256;
-        const int blocks = static_cast<int>
-        (
-            (nCells + threadsPerBlock - 1)/threadsPerBlock
-        );
-
-        int nCellsInt = static_cast<int>(nCells);
-        scalar kernelCmu = Cmu;
-        scalar kernelKmin = kMin;
-        scalar kernelEpsilonMin = epsilonMin;
-
-        void* args[] =
-        {
-            &dNut,
-            &dK,
-            &dEps,
-            &kernelCmu,
-            &kernelKmin,
-            &kernelEpsilonMin,
-            &nCellsInt
-        };
-
-        status = cuLaunchKernel
-        (
-            correctNutKernel_,
-            blocks, 1, 1,
-            threadsPerBlock, 1, 1,
-            0,
-            nullptr,
-            args,
-            nullptr
-        );
-
-        ok = ok && status == CUDA_SUCCESS;
-
-        if (ok)
-        {
-            status = cuCtxSynchronize();
-            ok = ok && status == CUDA_SUCCESS;
-        }
-
-        if (ok)
-        {
-            status = cuMemcpyDtoH(nut, dNut, bytes);
-            ok = ok && status == CUDA_SUCCESS;
-        }
-
-        cuMemFree(dNut);
-        cuMemFree(dK);
-        cuMemFree(dEps);
-
-        return ok;
-    }
-};
-
-
-inline kEpsilonCudaBackend& getKepsilonCudaBackend()
-{
-    static kEpsilonCudaBackend backend;
-    return backend;
-}
-
-} // End anonymous namespace
-
-#endif
 
 template<class BasicMomentumTransportModel>
 void kEpsilon<BasicMomentumTransportModel>::refreshGpuConfig()
 {
-    bool requestedGpu = false;
+    bool requestedGpu = true;
 
     Switch gpuSwitch(false);
     if (gpuSwitch.readIfPresent("useGPU", this->coeffDict_))
@@ -519,19 +90,21 @@ void kEpsilon<BasicMomentumTransportModel>::refreshGpuConfig()
 
     useGpu_ = requestedGpu;
 
-    gpuDeviceId_ = this->coeffDict_.template lookupOrDefault<label>("gpuDevice", gpuDeviceId_);
-    gpuDeviceId_ = this->coeffDict_.template lookupOrDefault<label>("deviceId", gpuDeviceId_);
-
-    gpuOperational_ = useGpu_;
-
-#ifndef FOAM_USE_CUDA
+#ifdef FOAM_USE_CUDA
+    if (useGpu_ && !Foam::gpu::available())
+    {
+        WarningInFunction
+            << "kEpsilon GPU backend requested but CUDA context is unavailable"
+            << nl << "Continuing with CPU implementation." << endl;
+        useGpu_ = false;
+    }
+#else
     if (useGpu_)
     {
         WarningInFunction
-            << "kEpsilon GPU backend requested but this build lacks CUDA support" << nl
-            << "Continuing with CPU implementation." << endl;
+            << "kEpsilon GPU backend requested but this build lacks CUDA support"
+            << nl << "Continuing with CPU implementation." << endl;
         useGpu_ = false;
-        gpuOperational_ = false;
     }
 #endif
 }
@@ -543,57 +116,48 @@ void kEpsilon<BasicMomentumTransportModel>::correctNut()
 {
     bool usedGpu = false;
 
-#ifdef FOAM_USE_CUDA
-    if (useGpu_ && gpuOperational_)
+    if (useGpu_)
     {
-        std::string setupMessage;
-        auto& backend = getKepsilonCudaBackend();
-
-        if (!backend.prepare(gpuDeviceId_, setupMessage))
+        Foam::gpu::Context& ctx = Foam::gpu::globalContext();
+        if (ctx.ready())
         {
-            gpuOperational_ = false;
-            if (!setupMessage.empty())
-            {
-                WarningInFunction
-                    << "kEpsilon GPU backend initialisation failed: "
-                    << setupMessage << nl << "Falling back to CPU path." << endl;
-            }
-        }
-        else
-        {
-            scalarField& nutInternal = this->nut_.primitiveFieldRef();
-            const scalarField& kInternal = k_.primitiveField();
-            const scalarField& epsilonInternal = epsilon_.primitiveField();
+            Foam::gpu::FieldRegistry& registry =
+                Foam::gpu::FieldRegistry::New(this->mesh_);
 
+            Foam::gpu::DeviceField<volScalarField>& nutDev =
+                registry.getOrCreate(this->nut_);
+            Foam::gpu::DeviceField<volScalarField>& kDev =
+                registry.getOrCreate(k_);
+            Foam::gpu::DeviceField<volScalarField>& epsilonDev =
+                registry.getOrCreate(epsilon_);
+
+            word gpuError;
             if
             (
-                nutInternal.size() == kInternal.size()
-             && nutInternal.size() == epsilonInternal.size()
-             && nutInternal.size() == this->mesh_.nCells()
-            )
-            {
-                usedGpu = backend.launchCorrectNut
+                Foam::gpu::computeNutFromKEpsilon
                 (
-                    nutInternal.begin(),
-                    kInternal.begin(),
-                    epsilonInternal.begin(),
-                    nutInternal.size(),
+                    ctx,
+                    nutDev,
+                    kDev,
+                    epsilonDev,
                     Cmu_.value(),
                     this->kMin_.value(),
-                    this->epsilonMin_.value()
-                );
-            }
-
-            if (!usedGpu)
+                    this->epsilonMin_.value(),
+                    gpuError,
+                    nullptr
+                )
+            )
             {
-                gpuOperational_ = false;
+                usedGpu = true;
+            }
+            else if (!gpuError.empty())
+            {
                 WarningInFunction
-                    << "kEpsilon GPU kernel launch failed; reverting to CPU path"
-                    << endl;
+                    << "kEpsilon GPU nut update failed: "
+                    << gpuError << nl << "Falling back to CPU path." << endl;
             }
         }
     }
-#endif
 
     if (!usedGpu)
     {
@@ -622,6 +186,40 @@ void kEpsilon<BasicMomentumTransportModel>::correctNut()
 
     this->nut_.correctBoundaryConditions();
     fvConstraints::New(this->mesh_).constrain(this->nut_);
+
+    if (useGpu_)
+    {
+        Foam::gpu::Context& ctx = Foam::gpu::globalContext();
+        if (ctx.ready())
+        {
+            Foam::gpu::FieldRegistry& registry =
+                Foam::gpu::FieldRegistry::New(this->mesh_);
+
+            word syncError;
+            Foam::gpu::DeviceField<volScalarField>& nutDev =
+                registry.getOrCreate(this->nut_);
+            Foam::gpu::DeviceField<volScalarField>& kDev =
+                registry.getOrCreate(k_);
+            Foam::gpu::DeviceField<volScalarField>& epsDev =
+                registry.getOrCreate(epsilon_);
+
+            nutDev.markHostDirty();
+            kDev.markHostDirty();
+            epsDev.markHostDirty();
+
+            if
+            (
+                !nutDev.syncHostToDevice(ctx, syncError)
+             || !kDev.syncHostToDevice(ctx, syncError)
+             || !epsDev.syncHostToDevice(ctx, syncError)
+            )
+            {
+                WarningInFunction
+                    << "Failed to synchronise turbulence fields to GPU: "
+                    << syncError << endl;
+            }
+        }
+    }
 }
 
 
@@ -759,9 +357,7 @@ kEpsilon<BasicMomentumTransportModel>::kEpsilon
         ),
         this->mesh_
     ),
-    useGpu_(false),
-    gpuOperational_(false),
-    gpuDeviceId_(0)
+    useGpu_(false)
 {
     bound(k_, this->kMin_);
     bound(epsilon_, this->epsilonMin_);

--- a/src/MomentumTransportModels/momentumTransportModels/RAS/kEpsilon/kEpsilon.H
+++ b/src/MomentumTransportModels/momentumTransportModels/RAS/kEpsilon/kEpsilon.H
@@ -106,8 +106,6 @@ protected:
         // GPU configuration
 
             bool useGpu_;
-            bool gpuOperational_;
-            label gpuDeviceId_;
 
         //- Refresh GPU configuration values from the coefficients dictionary
         void refreshGpuConfig();

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.C
@@ -1,0 +1,82 @@
+#include "CsrExport.H"
+#include "lduAddressing.H"
+
+namespace Foam
+{
+namespace cudaPCGDetail
+{
+
+CsrMatrix buildSymmetricCsr(const lduMatrix& A)
+{
+    const scalarField& diag = A.diag();
+    const label n = diag.size();
+
+    const lduAddressing& addr = A.lduAddr();
+    const labelUList& lowerAddr = addr.lowerAddr();
+    const labelUList& upperAddr = addr.upperAddr();
+
+    const label nFaces = lowerAddr.size();
+
+    // Deg counts per row (start with 1 for the diagonal)
+    labelList deg(n, 1);
+    for (label f = 0; f < nFaces; ++f)
+    {
+        const label i = lowerAddr[f];
+        const label j = upperAddr[f];
+        ++deg[i];
+        ++deg[j];
+    }
+
+    CsrMatrix M;
+    M.nRows = n;
+    M.rowPtr.setSize(n+1);
+    M.rowPtr[0] = 0;
+    for (label i = 0; i < n; ++i)
+    {
+        M.rowPtr[i+1] = M.rowPtr[i] + deg[i];
+    }
+    M.nnz = M.rowPtr[n];
+    M.colInd.setSize(M.nnz);
+    M.values.setSize(M.nnz);
+
+    // Cursor per row
+    labelList next(M.rowPtr);
+
+    // Put diagonal entries first
+    for (label i = 0; i < n; ++i)
+    {
+        const label pos = next[i]++;
+        M.colInd[pos] = i;
+        M.values[pos] = diag[i];
+    }
+
+    const scalarField& upper = A.upper();
+    const scalarField& lower = A.lower();
+
+    // Off-diagonals: for each face add A(i,j) and A(j,i)
+    for (label f = 0; f < nFaces; ++f)
+    {
+        const label i = lowerAddr[f];
+        const label j = upperAddr[f];
+
+        // row i, col j uses upper[f]
+        {
+            const label pos = next[i]++;
+            M.colInd[pos] = j;
+            M.values[pos] = upper[f];
+        }
+
+        // row j, col i uses lower[f]
+        {
+            const label pos = next[j]++;
+            M.colInd[pos] = i;
+            M.values[pos] = lower[f];
+        }
+    }
+
+    return M;
+}
+
+} // namespace cudaPCGDetail
+} // namespace Foam
+

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.C
@@ -1,5 +1,6 @@
 #include "CsrExport.H"
 #include "lduAddressing.H"
+#include "DynamicList.H"
 
 namespace Foam
 {
@@ -77,6 +78,131 @@ CsrMatrix buildSymmetricCsr(const lduMatrix& A)
     return M;
 }
 
+Colouring buildGreedyColouring(const lduMatrix& A)
+{
+    const scalarField& diag = A.diag();
+    const label n = diag.size();
+
+    Colouring result;
+    if (!n)
+    {
+        result.nColours = 0;
+        result.colourPtr.setSize(1, 0);
+        return result;
+    }
+
+    const lduAddressing& addr = A.lduAddr();
+    const labelUList& lowerAddr = addr.lowerAddr();
+    const labelUList& upperAddr = addr.upperAddr();
+    const label nFaces = lowerAddr.size();
+
+    List<DynamicList<label>> adjacency(n);
+
+    for (label face = 0; face < nFaces; ++face)
+    {
+        const label owner = lowerAddr[face];
+        const label neighbour = upperAddr[face];
+        adjacency[owner].append(neighbour);
+        adjacency[neighbour].append(owner);
+    }
+
+    labelList colours(n, -1);
+    DynamicList<label> touched;
+    List<char> usedColours(0);
+
+    label maxColour = 0;
+
+    for (label cell = 0; cell < n; ++cell)
+    {
+        DynamicList<label>& nbrs = adjacency[cell];
+
+        forAll(nbrs, i)
+        {
+            const label nbr = nbrs[i];
+            const label colour = colours[nbr];
+            if (colour < 0)
+            {
+                continue;
+            }
+
+            if (colour >= usedColours.size())
+            {
+                const label oldSize = usedColours.size();
+                usedColours.setSize(colour + 1);
+                for (label j = oldSize; j < usedColours.size(); ++j)
+                {
+                    usedColours[j] = 0;
+                }
+            }
+
+            if (!usedColours[colour])
+            {
+                usedColours[colour] = 1;
+                touched.append(colour);
+            }
+        }
+
+        label chosen = 0;
+        for (; chosen < usedColours.size(); ++chosen)
+        {
+            if (!usedColours[chosen])
+            {
+                break;
+            }
+        }
+
+        if (chosen == usedColours.size())
+        {
+            usedColours.append(0);
+        }
+
+        colours[cell] = chosen;
+        maxColour = max(maxColour, chosen + 1);
+
+        forAll(touched, ti)
+        {
+            usedColours[touched[ti]] = 0;
+        }
+        touched.clear();
+    }
+
+    if (!maxColour)
+    {
+        // All cells isolated – assign a single colour.
+        maxColour = 1;
+        colours = 0;
+    }
+
+    result.nColours = maxColour;
+    result.cellToColour.transfer(colours);
+
+    result.colourPtr.setSize(result.nColours + 1);
+    result.colourPtr[0] = 0;
+    labelList counts(result.nColours, 0);
+    forAll(result.cellToColour, idx)
+    {
+        const label colour = result.cellToColour[idx];
+        if (colour >= 0 && colour < result.nColours)
+        {
+            ++counts[colour];
+        }
+    }
+    for (label c = 0; c < result.nColours; ++c)
+    {
+        result.colourPtr[c+1] = result.colourPtr[c] + counts[c];
+    }
+
+    result.colourIndices.setSize(n);
+    labelList cursor(result.colourPtr);
+    forAll(result.cellToColour, cell)
+    {
+        const label colour = result.cellToColour[cell];
+        const label pos = cursor[colour]++;
+        result.colourIndices[pos] = cell;
+    }
+
+    return result;
+}
+
 } // namespace cudaPCGDetail
 } // namespace Foam
-

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.H
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.H
@@ -1,0 +1,34 @@
+/*
+    Minimal CSR exporter for OpenFOAM lduMatrix (symmetric full CSR)
+    Phase 1 utility – local to cudaPCG implementation.
+*/
+
+#ifndef CsrExport_H
+#define CsrExport_H
+
+#include "lduMatrix.H"
+#include "List.H"
+#include "labelList.H"
+#include "scalarField.H"
+
+namespace Foam
+{
+namespace cudaPCGDetail
+{
+
+struct CsrMatrix
+{
+    label nRows;
+    label nnz;
+    labelList rowPtr;   // size nRows+1
+    labelList colInd;   // size nnz
+    scalarField values; // size nnz
+};
+
+// Build a full symmetric CSR (diagonal + both off-diagonal entries)
+CsrMatrix buildSymmetricCsr(const lduMatrix& A);
+
+} // namespace cudaPCGDetail
+} // namespace Foam
+
+#endif

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.H
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/CsrExport.H
@@ -25,8 +25,26 @@ struct CsrMatrix
     scalarField values; // size nnz
 };
 
+struct Colouring
+{
+    //- Number of colours produced by the greedy colouring
+    label nColours;
+
+    //- Colour index per cell/row (size nRows)
+    labelList cellToColour;
+
+    //- Offsets into colourIndices for each colour (size nColours+1)
+    labelList colourPtr;
+
+    //- Row indices grouped by colour
+    labelList colourIndices;
+};
+
 // Build a full symmetric CSR (diagonal + both off-diagonal entries)
 CsrMatrix buildSymmetricCsr(const lduMatrix& A);
+
+// Greedy graph colouring for the cell adjacency implied by the matrix
+Colouring buildGreedyColouring(const lduMatrix& A);
 
 } // namespace cudaPCGDetail
 } // namespace Foam

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/files
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/files
@@ -1,0 +1,4 @@
+cudaPCG.C
+CsrExport.C
+
+LIB = $(FOAM_USER_LIBBIN)/libcudaPCG

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/options
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/options
@@ -1,0 +1,17 @@
+EXE_INC = \
+    -I$(LIB_SRC)/OpenFOAM/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I/usr/local/cuda/include \
+    -DFOAM_USE_CUDA
+
+LIB_LIBS = \
+    -lOpenFOAM \
+    -lfiniteVolume \
+    -lmeshTools \
+    -L/usr/local/cuda/lib64 \
+    -lcuda \
+    -lcudart \
+    -lcusparse \
+    -lcusolver \
+    -lcublas

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/options
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/Make/options
@@ -14,4 +14,5 @@ LIB_LIBS = \
     -lcudart \
     -lcusparse \
     -lcusolver \
-    -lcublas
+    -lcublas \
+    -lnvrtc

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -500,6 +500,44 @@ Foam::solverPerformance Foam::cudaPCG::solve
     dictionary cpuDict(controlDict_);
     cpuDict.set("solver", word("PCG"));
 
+    // Ensure CPU compatibility: translate GPU-only preconditioners
+    // If the case configured an unknown preconditioner (e.g. "sgs" or "colour"),
+    // fall back to a stock CPU preconditioner to avoid runtime aborts
+    // when constructing the CPU PCG.
+    {
+        const word precon = cpuDict.lookupOrDefault<word>("preconditioner", word("DIC"));
+        const word lower = toLower(precon);
+
+        // Normalise to CPU-registered names
+        if (lower == word("sgs") || lower == word("symgaussseidel")
+         || lower == word("ic") || lower == word("dic")
+         || lower == word("colour") || lower == word("colored") || lower == word("coloured"))
+        {
+            cpuDict.set("preconditioner", word("DIC"));
+        }
+        else if (lower == word("fdic"))
+        {
+            cpuDict.set("preconditioner", word("FDIC"));
+        }
+        else if (lower == word("gamg"))
+        {
+            cpuDict.set("preconditioner", word("GAMG"));
+        }
+        else if (lower == word("diagonal") || lower == word("none"))
+        {
+            // keep as-is (already lowercase) – both are registered names
+            cpuDict.set("preconditioner", lower);
+        }
+
+        // Remove GPU-only tuning entries that some CPU preconditioners do not recognise
+        // (silently ignore if absent).
+        cpuDict.remove("colourOmega");
+        cpuDict.remove("colourBackwardOmega");
+        cpuDict.remove("polyJacobiAuto");
+        cpuDict.remove("polyJacobiSweeps");
+        cpuDict.remove("jacobiOmega");
+    }
+
     autoPtr<lduMatrix::solver> cpuSolver = lduMatrix::solver::New
     (
         fieldName_,
@@ -645,6 +683,7 @@ bool Foam::cudaPCG::gpuSolve
     double iterationAccumSeconds = 0.0;
     double iterationMaxSeconds = 0.0;
     label iterationCountStats = 0;
+    label stallCounter = 0;
 
     cudaError_t cudaCode = cudaSetDevice(deviceId);
     if (cudaCode != cudaSuccess)
@@ -679,25 +718,65 @@ using DeviceScalar = double;
     }
 
     const scalarField& diag = matrix_.diag();
+    const scalar diagFloorAbsCfg =
+        controlDict_.lookupOrDefault<scalar>("preconditionerDiagFloor", scalar(1e-20));
+    const scalar diagFloorRelCfg =
+        controlDict_.lookupOrDefault<scalar>("preconditionerDiagRelFloor", scalar(0));
+
     scalar minDiag = std::numeric_limits<scalar>::max();
     scalar maxDiag = -std::numeric_limits<scalar>::max();
+    scalar maxAbsDiag = 0;
     for (const scalar d : diag)
     {
         minDiag = std::min(minDiag, d);
         maxDiag = std::max(maxDiag, d);
+        maxAbsDiag = std::max(maxAbsDiag, mag(d));
+    }
+
+    const scalar diagFloorCfg = std::max(diagFloorAbsCfg, diagFloorRelCfg*maxAbsDiag);
+
+    const labelUList& upperAddr = matrix_.lduAddr().upperAddr();
+    const labelUList& lowerAddr = matrix_.lduAddr().lowerAddr();
+    const scalarField& upper = matrix_.upper();
+
+    scalarField dicDiag(diag);
+    forAll(dicDiag, i)
+    {
+        scalar& d = dicDiag[i];
+        d = std::max(mag(d), diagFloorCfg);
+    }
+
+    const label nFaces = upper.size();
+    for (label face = 0; face < nFaces; ++face)
+    {
+        const label upCell = upperAddr[face];
+        const label lowCell = lowerAddr[face];
+        const scalar lowDiag = dicDiag[lowCell];
+        const scalar denom = std::max(mag(lowDiag), diagFloorCfg);
+        dicDiag[upCell] -= (upper[face]*upper[face])/denom;
+    }
+
+    scalar minDiagReg = std::numeric_limits<scalar>::max();
+    scalar maxDiagReg = -std::numeric_limits<scalar>::max();
+    List<DeviceScalar> precondDiag(dicDiag.size());
+    List<DeviceScalar> diagInv(dicDiag.size());
+
+    forAll(dicDiag, i)
+    {
+        scalar reg = std::max(mag(dicDiag[i]), diagFloorCfg);
+        minDiagReg = std::min(minDiagReg, reg);
+        maxDiagReg = std::max(maxDiagReg, reg);
+        precondDiag[i] = static_cast<DeviceScalar>(reg);
+        diagInv[i] = mag(reg) > VSMALL
+            ? static_cast<DeviceScalar>(1.0/reg)
+            : static_cast<DeviceScalar>(0);
     }
 
     if (reportStats)
     {
         Info<< "cudaPCG: diagonal range [" << minDiag << ", " << maxDiag << "]"
+            << " (regularised [" << minDiagReg << ", " << maxDiagReg << "])"
             << nl;
-    }
-
-    List<DeviceScalar> diagInv(diag.size());
-    forAll(diag, i)
-    {
-        const scalar d = diag[i];
-        diagInv[i] = mag(d) > VSMALL ? static_cast<DeviceScalar>(1.0/d) : static_cast<DeviceScalar>(0);
     }
 
     DeviceScalar *d_vals=nullptr, *d_x=nullptr, *d_b=nullptr;
@@ -746,6 +825,13 @@ using DeviceScalar = double;
     bool usePolyJacobi = (!useColour && !useSGS) && ((polySweepsCfg > 0) || polyAuto);
     label polySweepsEff = polySweepsCfg;
     double jacOmegaEff = static_cast<double>(jacOmegaCfg);
+
+    const Switch earlyAbortOnStall =
+        controlDict_.lookupOrDefault<Switch>("earlyAbortOnStall", Switch(false));
+    const label stallWindow =
+        std::max<label>(1, controlDict_.lookupOrDefault<label>("stallWindow", 50));
+    const scalar stallRatioTol =
+        controlDict_.lookupOrDefault<scalar>("stallRatioTol", scalar(0.99));
 
     const scalar colourOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourOmega", scalar(0.65));
     const scalar colourBackwardOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourBackwardOmega", scalar(0.85));
@@ -1239,6 +1325,8 @@ using DeviceScalar = double;
 
     // Build optional SGS preconditioner structures: CSR of (D+L)
     bool sgsReady = false;
+    bool sgsBuiltSuccessfully = false;
+    std::string sgsDisableReason;
     int preRows = 0, preNnz = 0;
     if (useSGS)
     {
@@ -1267,9 +1355,11 @@ using DeviceScalar = double;
                 if (j <= i)
                 {
                     preColIndHost[cursor] = j;
-                    // Optional tiny diagonal regularisation if needed
                     DeviceScalar v = values[k];
-                    if (j == i && std::abs(v) < 1e-20) v = (v >= 0 ? 1 : -1)*1e-20;
+                    if (j == i)
+                    {
+                        v = precondDiag[i];
+                    }
                     preValsHost[cursor] = v;
                     ++cursor;
                 }
@@ -1384,10 +1474,15 @@ using DeviceScalar = double;
                         )
                         {
                             sgsReady = true;
+                            sgsBuiltSuccessfully = true;
                         }
                     }
                 }
             }
+        }
+        else
+        {
+            sgsDisableReason = std::string("allocOrDescrCreate");
         }
     }
 
@@ -1891,6 +1986,22 @@ using DeviceScalar = double;
         return applyDiagonalDevice(rhs, out);
     };
 
+    // Emit one-line SGS status when requested
+    if (reportStats && useSGS)
+    {
+        if (sgsReady)
+        {
+            Info<< "cudaPCG(" << fieldName_ << "): SGS preconditioner active (rows="
+                << rows << ", nnz=" << preNnz << ")" << nl;
+        }
+        else
+        {
+            Info<< "cudaPCG(" << fieldName_ << "): SGS preconditioner disabled ("
+                << (sgsDisableReason.size() ? sgsDisableReason : std::string("buildFailure"))
+                << ")" << nl;
+        }
+    }
+
     const double alpha = 1.0;
     const double zero = 0.0;
     const double negOne = -1.0;
@@ -2291,6 +2402,32 @@ using DeviceScalar = double;
         sumAbs = returnReduce(static_cast<scalar>(sumAbsDevice), sumOp<scalar>());
 
         solverPerf.finalResidual() = sumAbs/normFactor;
+
+        if (earlyAbortOnStall)
+        {
+            const scalar initRes = solverPerf.initialResidual();
+            if (initRes > VSMALL)
+            {
+                scalar ratio = solverPerf.finalResidual()/initRes;
+                if (!std::isfinite(ratio))
+                {
+                    return fail("stallDetected");
+                }
+                if (ratio > stallRatioTol)
+                {
+                    ++stallCounter;
+                }
+                else
+                {
+                    stallCounter = 0;
+                }
+
+                if (stallCounter >= stallWindow)
+                {
+                    return fail("stallDetected");
+                }
+            }
+        }
 
         ++iter;
         solverPerf.nIterations() = iter;

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -1,0 +1,551 @@
+#include "cudaPCG.H"
+#include "PCG.H"
+#include "CsrExport.H"
+#include "Switch.H"
+#include "List.H"
+
+#include <algorithm>
+
+#ifdef FOAM_USE_CUDA
+#include <cuda_runtime.h>
+#define CUSPARSE_USE_DEPRECATED_API
+#include <cusparse_v2.h>
+#include <cusparse.h>
+#include <cublas_v2.h>
+#endif
+
+namespace Foam
+{
+    defineTypeNameAndDebug(cudaPCG, 0);
+
+    lduMatrix::solver::addsymMatrixConstructorToTable<cudaPCG>
+        addCudaPCGSymMatrixConstructorToTable_;
+}
+
+namespace
+{
+inline std::string toLower(const std::string& s)
+{
+    std::string out(s);
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c){ return std::tolower(c); });
+    return out;
+}
+}
+
+Foam::cudaPCG::cudaPCG
+(
+    const word& fieldName,
+    const lduMatrix& matrix,
+    const FieldField<Field, scalar>& interfaceBouCoeffs,
+    const FieldField<Field, scalar>& interfaceIntCoeffs,
+    const lduInterfaceFieldPtrsList& interfaces,
+    const dictionary& solverControls
+)
+:
+    lduMatrix::solver
+    (
+        fieldName,
+        matrix,
+        interfaceBouCoeffs,
+        interfaceIntCoeffs,
+        interfaces,
+        solverControls
+    )
+{}
+
+Foam::solverPerformance Foam::cudaPCG::solve
+(
+    scalarField& psi,
+    const scalarField& source,
+    const direction cmpt
+) const
+{
+    bool requestedGpu = false;
+
+    Switch gpuSwitch(false);
+    if (gpuSwitch.readIfPresent("useGPU", controlDict_))
+    {
+        requestedGpu = gpuSwitch;
+    }
+
+    if (!requestedGpu)
+    {
+        const word deviceWord = controlDict_.lookupOrDefault<word>("device", "gpu");
+        const std::string deviceLower = toLower(deviceWord);
+        requestedGpu = deviceLower == "gpu" || deviceLower == "cuda";
+
+        if (!requestedGpu && controlDict_.found("backend"))
+        {
+            const word backend = controlDict_.lookup<word>("backend");
+            const std::string backendLower = toLower(backend);
+            requestedGpu = backendLower == "gpu" || backendLower == "cuda";
+        }
+    }
+
+    const label requestedDevice = controlDict_.lookupOrDefault<label>("gpuDevice", 0);
+    const label deviceId = controlDict_.lookupOrDefault<label>("deviceId", requestedDevice);
+
+#ifdef FOAM_USE_CUDA
+    if (requestedGpu)
+    {
+        solverPerformance gpuPerf
+        (
+            lduMatrix::preconditioner::getName(controlDict_) + typeName,
+            fieldName_
+        );
+
+        word message;
+        if (gpuSolve(psi, source, cmpt, gpuPerf, deviceId, message))
+        {
+            return gpuPerf;
+        }
+
+        WarningInFunction
+            << "cudaPCG GPU path disabled: " << message << nl
+            << "Falling back to CPU PCG." << endl;
+    }
+#else
+    if (requestedGpu)
+    {
+        WarningInFunction
+            << "cudaPCG requested GPU backend but this build lacks CUDA support" << nl
+            << "Continuing with CPU solver." << endl;
+    }
+#endif
+
+    dictionary cpuDict(controlDict_);
+    cpuDict.set("solver", word("PCG"));
+
+    autoPtr<lduMatrix::solver> cpuSolver = lduMatrix::solver::New
+    (
+        fieldName_,
+        matrix_,
+        interfaceBouCoeffs_,
+        interfaceIntCoeffs_,
+        interfaces_,
+        cpuDict
+    );
+
+    return cpuSolver->solve(psi, source, cmpt);
+}
+
+#ifdef FOAM_USE_CUDA
+
+namespace
+{
+inline const char* cudaStatusName(cudaError_t code)
+{
+    return cudaGetErrorName(code);
+}
+
+inline const char* cusparseStatusName(cusparseStatus_t code)
+{
+    return cusparseGetErrorString(code);
+}
+
+inline const char* cublasStatusName(cublasStatus_t code)
+{
+    switch (code)
+    {
+        case CUBLAS_STATUS_SUCCESS: return "CUBLAS_STATUS_SUCCESS";
+        case CUBLAS_STATUS_NOT_INITIALIZED: return "CUBLAS_STATUS_NOT_INITIALIZED";
+        case CUBLAS_STATUS_ALLOC_FAILED: return "CUBLAS_STATUS_ALLOC_FAILED";
+        case CUBLAS_STATUS_INVALID_VALUE: return "CUBLAS_STATUS_INVALID_VALUE";
+        case CUBLAS_STATUS_ARCH_MISMATCH: return "CUBLAS_STATUS_ARCH_MISMATCH";
+        case CUBLAS_STATUS_MAPPING_ERROR: return "CUBLAS_STATUS_MAPPING_ERROR";
+        case CUBLAS_STATUS_EXECUTION_FAILED: return "CUBLAS_STATUS_EXECUTION_FAILED";
+        case CUBLAS_STATUS_INTERNAL_ERROR: return "CUBLAS_STATUS_INTERNAL_ERROR";
+#ifdef CUBLAS_STATUS_NOT_SUPPORTED
+        case CUBLAS_STATUS_NOT_SUPPORTED: return "CUBLAS_STATUS_NOT_SUPPORTED";
+#endif
+#ifdef CUBLAS_STATUS_LICENSE_ERROR
+        case CUBLAS_STATUS_LICENSE_ERROR: return "CUBLAS_STATUS_LICENSE_ERROR";
+#endif
+        default: return "CUBLAS_STATUS_UNKNOWN";
+    }
+}
+} // namespace
+
+bool Foam::cudaPCG::gpuSolve
+(
+    scalarField& psi,
+    const scalarField& source,
+    const direction cmpt,
+    solverPerformance& solverPerf,
+    const label deviceId,
+    word& message
+) const
+{
+    message.clear();
+
+    const label nCells = psi.size();
+    if (!nCells)
+    {
+        solverPerf.finalResidual() = 0;
+        solverPerf.initialResidual() = 0;
+        return true;
+    }
+
+    cudaError_t cudaCode = cudaSetDevice(deviceId);
+    if (cudaCode != cudaSuccess)
+    {
+        message = word("cudaSetDevice: ") + cudaStatusName(cudaCode);
+        return false;
+    }
+
+    cudaPCGDetail::CsrMatrix csrMatrix = cudaPCGDetail::buildSymmetricCsr(matrix_);
+    if (csrMatrix.nRows != nCells)
+    {
+        message = "CSR row mismatch";
+        return false;
+    }
+
+    static_assert(sizeof(scalar) == sizeof(double), "cudaPCG currently requires double precision build");
+
+    using DeviceScalar = double;
+
+    const int rows = static_cast<int>(csrMatrix.nRows);
+    const int nnz = static_cast<int>(csrMatrix.nnz);
+
+    List<int> rowPtr(rows + 1);
+    List<int> colInd(nnz);
+    List<DeviceScalar> values(nnz);
+
+    for (int i=0; i<=rows; ++i) rowPtr[i] = static_cast<int>(csrMatrix.rowPtr[i]);
+    for (int i=0; i<nnz; ++i)
+    {
+        colInd[i] = static_cast<int>(csrMatrix.colInd[i]);
+        values[i] = static_cast<DeviceScalar>(csrMatrix.values[i]);
+    }
+
+    const scalarField& diag = matrix_.diag();
+    List<DeviceScalar> diagInv(diag.size());
+    forAll(diag, i)
+    {
+        const scalar d = diag[i];
+        diagInv[i] = mag(d) > VSMALL ? static_cast<DeviceScalar>(1.0/d) : static_cast<DeviceScalar>(0);
+    }
+
+    DeviceScalar *d_vals=nullptr, *d_x=nullptr, *d_b=nullptr;
+    DeviceScalar *d_r=nullptr, *d_p=nullptr, *d_Ap=nullptr;
+    DeviceScalar *d_z=nullptr, *d_diagInv=nullptr;
+    int *d_rowPtr=nullptr, *d_colInd=nullptr;
+    cusparseHandle_t cusparseHandle = nullptr;
+    cublasHandle_t cublasHandle = nullptr;
+    cusparseSpMatDescr_t matA = nullptr;
+    cusparseDnVecDescr_t vecX = nullptr;
+    cusparseDnVecDescr_t vecY = nullptr;
+    void* spmvBuffer = nullptr;
+
+    auto cleanup = [&]()
+    {
+        if (vecX)
+        {
+            cusparseDestroyDnVec(vecX);
+            vecX = nullptr;
+        }
+        if (vecY)
+        {
+            cusparseDestroyDnVec(vecY);
+            vecY = nullptr;
+        }
+        if (matA)
+        {
+            cusparseDestroySpMat(matA);
+            matA = nullptr;
+        }
+        if (spmvBuffer)
+        {
+            cudaFree(spmvBuffer);
+            spmvBuffer = nullptr;
+        }
+        if (cublasHandle)
+        {
+            cublasDestroy(cublasHandle);
+            cublasHandle = nullptr;
+        }
+        if (cusparseHandle)
+        {
+            cusparseDestroy(cusparseHandle);
+            cusparseHandle = nullptr;
+        }
+
+        if (d_vals) cudaFree(d_vals);
+        if (d_x) cudaFree(d_x);
+        if (d_b) cudaFree(d_b);
+        if (d_r) cudaFree(d_r);
+        if (d_p) cudaFree(d_p);
+        if (d_Ap) cudaFree(d_Ap);
+        if (d_z) cudaFree(d_z);
+        if (d_diagInv) cudaFree(d_diagInv);
+        if (d_rowPtr) cudaFree(d_rowPtr);
+        if (d_colInd) cudaFree(d_colInd);
+    };
+
+    auto fail = [&](const word& msg)
+    {
+        cleanup();
+        message = msg;
+        return false;
+    };
+
+    // Allocate
+    if (cudaMalloc(reinterpret_cast<void**>(&d_vals), sizeof(DeviceScalar)*nnz) != cudaSuccess)
+        return fail("cudaMalloc(vals)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_rowPtr), sizeof(int)*(rows+1)) != cudaSuccess)
+        return fail("cudaMalloc(rowPtr)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_colInd), sizeof(int)*nnz) != cudaSuccess)
+        return fail("cudaMalloc(colInd)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_x), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(x)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_b), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(b)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_r), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(r)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_p), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(p)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_Ap), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(Ap)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_z), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(z)");
+    if (cudaMalloc(reinterpret_cast<void**>(&d_diagInv), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        return fail("cudaMalloc(diagInv)");
+
+    // Copy
+    if (cudaMemcpy(d_vals, values.begin(), sizeof(DeviceScalar)*nnz, cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(vals)");
+    if (cudaMemcpy(d_rowPtr, rowPtr.begin(), sizeof(int)*(rows+1), cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(rowPtr)");
+    if (cudaMemcpy(d_colInd, colInd.begin(), sizeof(int)*nnz, cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(colInd)");
+    if (cudaMemcpy(d_x, psi.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(x)");
+    if (cudaMemcpy(d_b, source.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(b)");
+    if (cudaMemcpy(d_diagInv, diagInv.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+        return fail("cudaMemcpy(diagInv)");
+
+    if (cusparseCreate(&cusparseHandle) != CUSPARSE_STATUS_SUCCESS)
+        return fail("cusparseCreate");
+    if (cublasCreate(&cublasHandle) != CUBLAS_STATUS_SUCCESS)
+        return fail("cublasCreate");
+
+    if
+    (
+        cusparseCreateCsr
+        (
+            &matA,
+            rows,
+            rows,
+            nnz,
+            d_rowPtr,
+            d_colInd,
+            d_vals,
+            CUSPARSE_INDEX_32I,
+            CUSPARSE_INDEX_32I,
+            CUSPARSE_INDEX_BASE_ZERO,
+            CUDA_R_64F
+        ) != CUSPARSE_STATUS_SUCCESS
+    )
+    {
+        return fail("cusparseCreateCsr");
+    }
+
+    if (cusparseCreateDnVec(&vecX, rows, d_x, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+        return fail("cusparseCreateDnVec(x)");
+    if (cusparseCreateDnVec(&vecY, rows, d_Ap, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+        return fail("cusparseCreateDnVec(y)");
+
+    const double alpha = 1.0;
+    const double zero = 0.0;
+    const double negOne = -1.0;
+
+    size_t bufferSize = 0;
+    if
+    (
+        cusparseSpMV_bufferSize
+        (
+            cusparseHandle,
+            CUSPARSE_OPERATION_NON_TRANSPOSE,
+            &alpha,
+            matA,
+            vecX,
+            &zero,
+            vecY,
+            CUDA_R_64F,
+            CUSPARSE_SPMV_ALG_DEFAULT,
+            &bufferSize
+        ) != CUSPARSE_STATUS_SUCCESS
+    )
+    {
+        return fail("cusparseSpMV_bufferSize");
+    }
+
+    if (bufferSize > 0)
+    {
+        if (cudaMalloc(&spmvBuffer, bufferSize) != cudaSuccess)
+        {
+            return fail("cudaMalloc(spmvBuffer)");
+        }
+    }
+
+    // r = b - A*x
+    if
+    (
+        cusparseSpMV
+        (
+            cusparseHandle,
+            CUSPARSE_OPERATION_NON_TRANSPOSE,
+            &alpha,
+            matA,
+            vecX,
+            &zero,
+            vecY,
+            CUDA_R_64F,
+            CUSPARSE_SPMV_ALG_DEFAULT,
+            spmvBuffer
+        ) != CUSPARSE_STATUS_SUCCESS
+    )
+    {
+        return fail("cusparseSpMV (A*x)");
+    }
+
+    if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_b), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
+        return fail("cublas copy b->r");
+    if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&negOne), reinterpret_cast<const double*>(d_Ap), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
+        return fail("cublas axpy r -= Ap");
+
+    if (cublasDdgmm(cublasHandle, CUBLAS_SIDE_LEFT, rows, 1, reinterpret_cast<const double*>(d_r), rows, reinterpret_cast<const double*>(d_diagInv), 1, reinterpret_cast<double*>(d_z), rows) != CUBLAS_STATUS_SUCCESS)
+        return fail("cublas dgmm diagInv*r");
+
+    if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+        return fail("cublas copy z->p");
+
+    scalarField rHost(nCells, Zero);
+    scalarField zHost(nCells, Zero);
+    scalarField pHost(nCells, Zero);
+    scalarField wA(nCells, Zero);
+    scalarField pA(nCells, Zero);
+
+    cudaMemcpy(rHost.begin(), d_r, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    cudaMemcpy(zHost.begin(), d_z, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    cudaMemcpy(wA.begin(), d_Ap, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    cudaMemcpy(pHost.begin(), d_p, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+
+    scalar rz = gSumProd(rHost, zHost, matrix_.mesh().comm());
+
+    scalar normFactor = this->normFactor(psi, source, wA, pA);
+
+    solverPerf.initialResidual() =
+        gSumMag(rHost, matrix_.mesh().comm())
+       /normFactor;
+    solverPerf.finalResidual() = solverPerf.initialResidual();
+
+    if
+    (
+        minIter_ <= 0
+     && solverPerf.checkConvergence(tolerance_, relTol_)
+    )
+    {
+        cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+        cleanup();
+        return true;
+    }
+
+    label iter = 0;
+
+    while
+    (
+        (
+          iter < maxIter_
+        && !solverPerf.checkConvergence(tolerance_, relTol_)
+        )
+     || iter < minIter_
+    )
+    {
+        if
+        (
+            cusparseDnVecSetValues(vecX, d_p) != CUSPARSE_STATUS_SUCCESS
+         || cusparseDnVecSetValues(vecY, d_Ap) != CUSPARSE_STATUS_SUCCESS
+         || cusparseSpMV
+            (
+                cusparseHandle,
+                CUSPARSE_OPERATION_NON_TRANSPOSE,
+                &alpha,
+                matA,
+                vecX,
+                &zero,
+                vecY,
+                CUDA_R_64F,
+                CUSPARSE_SPMV_ALG_DEFAULT,
+                spmvBuffer
+            ) != CUSPARSE_STATUS_SUCCESS
+        )
+        {
+            return fail("cusparseSpMV (A*p)");
+        }
+
+        // Restore vecX to x for completeness
+        cusparseDnVecSetValues(vecX, d_x);
+        cusparseDnVecSetValues(vecY, d_Ap);
+
+        cudaMemcpy(wA.begin(), d_Ap, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+        cudaMemcpy(pHost.begin(), d_p, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+
+        scalar pAp = gSumProd(wA, pHost, matrix_.mesh().comm());
+
+        if (solverPerf.checkSingularity(mag(pAp)/normFactor))
+        {
+            break;
+        }
+
+        const scalar alphaStep = rz/pAp;
+        const double alphaDevice = static_cast<double>(alphaStep);
+        const double negAlphaDevice = -alphaDevice;
+
+        if (cublasDaxpy(cublasHandle, rows, &alphaDevice, reinterpret_cast<const double*>(d_p), 1, reinterpret_cast<double*>(d_x), 1) != CUBLAS_STATUS_SUCCESS)
+            return fail("cublas axpy x += alpha*p");
+        if (cublasDaxpy(cublasHandle, rows, &negAlphaDevice, reinterpret_cast<const double*>(d_Ap), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
+            return fail("cublas axpy r -= alpha*Ap");
+
+        cudaMemcpy(rHost.begin(), d_r, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+
+        solverPerf.finalResidual() =
+            gSumMag(rHost, matrix_.mesh().comm())
+           /normFactor;
+
+        ++iter;
+        solverPerf.nIterations() = iter;
+
+        if
+        (
+            iter >= maxIter_
+         && solverPerf.checkConvergence(tolerance_, relTol_)
+        )
+        {
+            break;
+        }
+
+        if (cublasDdgmm(cublasHandle, CUBLAS_SIDE_LEFT, rows, 1, reinterpret_cast<const double*>(d_r), rows, reinterpret_cast<const double*>(d_diagInv), 1, reinterpret_cast<double*>(d_z), rows) != CUBLAS_STATUS_SUCCESS)
+            return fail("cublas dgmm diagInv*r (iter)");
+
+        cudaMemcpy(zHost.begin(), d_z, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+
+        const scalar rzOld = rz;
+        rz = gSumProd(rHost, zHost, matrix_.mesh().comm());
+
+        const scalar betaStep = rzOld != 0 ? rz/rzOld : 0;
+        const double betaDevice = static_cast<double>(betaStep);
+
+        if (cublasDscal(cublasHandle, rows, &betaDevice, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            return fail("cublas scal p*=beta");
+        if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&alpha), reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            return fail("cublas axpy p+=z");
+    }
+
+    cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    cleanup();
+    return true;
+}
+
+#endif

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -519,6 +519,11 @@ Foam::solverPerformance Foam::cudaPCG::solve
         {
             cpuDict.set("preconditioner", word("FDIC"));
         }
+        else if (lower == word("ilu0") || lower == word("ilu"))
+        {
+            // No ILU preconditioner in CPU registry; map to DIC
+            cpuDict.set("preconditioner", word("DIC"));
+        }
         else if (lower == word("gamg"))
         {
             cpuDict.set("preconditioner", word("GAMG"));
@@ -837,7 +842,7 @@ using DeviceScalar = double;
     label polySweepsCfg = controlDict_.lookupOrDefault<label>("polyJacobiSweeps", 0);
     scalar jacOmegaCfg = controlDict_.lookupOrDefault<scalar>("jacobiOmega", scalar(0.7));
     const Switch polyAuto = controlDict_.lookupOrDefault<Switch>("polyJacobiAuto", Switch(true));
-    bool usePolyJacobi = (!useColour && !useSGS) && ((polySweepsCfg > 0) || polyAuto);
+    bool usePolyJacobi = (!useColour && !useSGS && !useILU && !useIC) && ((polySweepsCfg > 0) || polyAuto);
     label polySweepsEff = polySweepsCfg;
     double jacOmegaEff = static_cast<double>(jacOmegaCfg);
 
@@ -1569,6 +1574,12 @@ using DeviceScalar = double;
             {
                 if (cusparseCreateCsrilu02Info(&iluInfo) == CUSPARSE_STATUS_SUCCESS)
                 {
+                    // Optional numeric boost to avoid zero pivots
+                    const Switch iluNumericBoost = controlDict_.lookupOrDefault<Switch>("iluNumericBoost", Switch(false));
+                    const scalar iluBoostTolCfg = controlDict_.lookupOrDefault<scalar>("iluNumericBoostTol", diagFloorCfg);
+                    const scalar iluBoostValCfg = controlDict_.lookupOrDefault<scalar>("iluNumericBoostVal", diagFloorCfg);
+                    double boostTol = static_cast<double>(iluBoostTolCfg);
+                    double boostVal = static_cast<double>(iluBoostValCfg);
                     int bs = 0;
                     if
                     (
@@ -1590,6 +1601,17 @@ using DeviceScalar = double;
                             iluInfo, CUSPARSE_SOLVE_POLICY_NO_LEVEL,
                             iluBuf
                         ) == CUSPARSE_STATUS_SUCCESS
+                     && (
+                        (!iluNumericBoost)
+                        || (cusparseDcsrilu02_numericBoost
+                            (
+                                cusparseHandle,
+                                iluInfo,
+                                1,
+                                &boostTol,
+                                &boostVal
+                            ) == CUSPARSE_STATUS_SUCCESS)
+                       )
                      && cusparseDcsrilu02
                         (
                             cusparseHandle, rows, nnz,
@@ -1601,6 +1623,15 @@ using DeviceScalar = double;
                         ) == CUSPARSE_STATUS_SUCCESS
                     )
                     {
+                        // Zero pivot check
+                        int pivot = -1;
+                        cusparseStatus_t zp = cusparseXcsrilu02_zeroPivot(cusparseHandle, iluInfo, &pivot);
+                        if (zp == CUSPARSE_STATUS_ZERO_PIVOT)
+                        {
+                            iluDisableReason = std::string("zeroPivot");
+                        }
+                        else
+                        {
                         if
                         (
                             cusparseCreateCsr(&matL, rows, rows, nnz, d_rowPtr, d_colInd, d_iluVals,
@@ -1689,6 +1720,7 @@ using DeviceScalar = double;
                                 }
                             }
                         }
+                        }
                     }
                     else
                     {
@@ -1736,6 +1768,15 @@ using DeviceScalar = double;
                         ) == CUSPARSE_STATUS_SUCCESS
                     )
                     {
+                        // Zero pivot check (IC0)
+                        int pivot = -1;
+                        cusparseStatus_t zp = cusparseXcsric02_zeroPivot(cusparseHandle, icInfo, &pivot);
+                        if (zp == CUSPARSE_STATUS_ZERO_PIVOT)
+                        {
+                            iluDisableReason = std::string("zeroPivot");
+                        }
+                        else
+                        {
                         if
                         (
                             cusparseCreateCsr(&matLchol, rows, rows, nnz, d_rowPtr, d_colInd, d_iluVals,
@@ -1817,6 +1858,7 @@ using DeviceScalar = double;
                                     }
                                 }
                             }
+                        }
                         }
                     }
                     else

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -510,7 +510,7 @@ Foam::solverPerformance Foam::cudaPCG::solve
 
         // Normalise to CPU-registered names
         if (lower == word("sgs") || lower == word("symgaussseidel")
-         || lower == word("ic") || lower == word("dic")
+         || lower == word("ic") || lower == word("ic0") || lower == word("dic")
          || lower == word("colour") || lower == word("colored") || lower == word("coloured"))
         {
             cpuDict.set("preconditioner", word("DIC"));
@@ -785,6 +785,16 @@ using DeviceScalar = double;
     int *d_rowPtr=nullptr, *d_colInd=nullptr;
     int *d_colors=nullptr, *d_colorIndices=nullptr;
     int *d_failFlag=nullptr;
+    // ILU/IC resources
+    DeviceScalar *d_iluVals = nullptr; // values for ILU/IC factors (separate from d_vals)
+    cusparseMatDescr_t iluDescr = nullptr;
+    csrilu02Info_t iluInfo = nullptr; // ILU0 info
+    csric02Info_t icInfo = nullptr;   // IC0 info
+    cusparseSpMatDescr_t matL = nullptr, matU = nullptr;      // ILU L and U
+    cusparseSpMatDescr_t matLchol = nullptr;                  // IC0 L
+    cusparseSpSVDescr_t spsvLowerIlu = nullptr, spsvUpperIlu = nullptr;
+    cusparseSpSVDescr_t spsvLowerChol = nullptr, spsvUpperTChol = nullptr;
+    void* iluBuf = nullptr; size_t iluBufSize = 0;
 
     // Preconditioner configuration
     const word preconditionerWord = controlDict_.lookupOrDefault<word>("preconditioner", word("diagonal"));
@@ -792,6 +802,8 @@ using DeviceScalar = double;
 
     bool useColour = false;
     bool useSGS = false;
+    bool useILU = false;
+    bool useIC = false;
 
     if
     (
@@ -806,15 +818,18 @@ using DeviceScalar = double;
     {
         useColour = true;
     }
-    else if
-    (
-        precondLower == "sgs"
-     || precondLower == "symgaussseidel"
-     || precondLower == "ic"
-     || precondLower == "dic"
-    )
+    else if (precondLower == "sgs" || precondLower == "symgaussseidel")
     {
         useSGS = true;
+    }
+    else if (precondLower == "ilu0" || precondLower == "ilu")
+    {
+        useILU = true;
+    }
+    else if (precondLower == "ic0" || precondLower == "ic" || precondLower == "dic")
+    {
+        // Map DIC to IC0 on GPU for closer parity with CPU
+        useIC = true;
     }
 
     colourInitiallyRequested = useColour;
@@ -1170,6 +1185,19 @@ using DeviceScalar = double;
         if (spsvUpperT) cusparseSpSV_destroyDescr(spsvUpperT);
         if (spsvBuf) cudaFree(spsvBuf);
         if (d_preTmp2) cudaFree(d_preTmp2);
+        // ILU/IC resources
+        if (matL) cusparseDestroySpMat(matL);
+        if (matU) cusparseDestroySpMat(matU);
+        if (matLchol) cusparseDestroySpMat(matLchol);
+        if (spsvLowerIlu) cusparseSpSV_destroyDescr(spsvLowerIlu);
+        if (spsvUpperIlu) cusparseSpSV_destroyDescr(spsvUpperIlu);
+        if (spsvLowerChol) cusparseSpSV_destroyDescr(spsvLowerChol);
+        if (spsvUpperTChol) cusparseSpSV_destroyDescr(spsvUpperTChol);
+        if (iluBuf) cudaFree(iluBuf);
+        if (iluInfo) cusparseDestroyCsrilu02Info(iluInfo);
+        if (icInfo) cusparseDestroyCsric02Info(icInfo);
+        if (iluDescr) cusparseDestroyMatDescr(iluDescr);
+        if (d_iluVals) cudaFree(d_iluVals);
         if (spmvGraphExec)
         {
             cudaGraphExecDestroy(spmvGraphExec);
@@ -1486,7 +1514,7 @@ using DeviceScalar = double;
         }
     }
 
-    if ((usePolyJacobi || useColour) && !d_preTmp)
+    if ((usePolyJacobi || useColour || useSGS || useILU || useIC) && !d_preTmp)
     {
         if (cudaMalloc(reinterpret_cast<void**>(&d_preTmp), sizeof(DeviceScalar)*rows) != cudaSuccess)
         {
@@ -1498,6 +1526,309 @@ using DeviceScalar = double;
         if (cudaMalloc(reinterpret_cast<void**>(&d_preTmp2), sizeof(DeviceScalar)*rows) != cudaSuccess)
         {
             return fail("cudaMalloc(preTmp2)");
+        }
+    }
+
+    // Build optional ILU0/IC0 preconditioner using cuSPARSE (legacy csrilu02/csric02)
+    bool iluReady = false;
+    bool icReady = false;
+    std::string iluDisableReason;
+    if ((useILU || useIC) && !preIn)
+    {
+        if (cusparseCreateDnVec(&preIn, rows, d_preTmp, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+        {
+            // preIn required for SpSV buffer sizing/analysis
+            useILU = false; useIC = false;
+        }
+        else if (cusparseCreateDnVec(&preOut, rows, d_preTmp, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+        {
+            useILU = false; useIC = false;
+        }
+    }
+    if (useILU || useIC)
+    {
+        // Allocate separate values array for in-place factorization
+        if (cudaMalloc(reinterpret_cast<void**>(&d_iluVals), sizeof(DeviceScalar)*nnz) != cudaSuccess)
+        {
+            iluDisableReason = std::string("allocVals");
+        }
+        else if (cudaMemcpy(d_iluVals, d_vals, sizeof(DeviceScalar)*nnz, cudaMemcpyDeviceToDevice) != cudaSuccess)
+        {
+            iluDisableReason = std::string("copyVals");
+        }
+        else if (cusparseCreateMatDescr(&iluDescr) != CUSPARSE_STATUS_SUCCESS)
+        {
+            iluDisableReason = std::string("createDescr");
+        }
+        else
+        {
+            cusparseSetMatType(iluDescr, CUSPARSE_MATRIX_TYPE_GENERAL);
+            cusparseSetMatIndexBase(iluDescr, CUSPARSE_INDEX_BASE_ZERO);
+
+            if (useILU)
+            {
+                if (cusparseCreateCsrilu02Info(&iluInfo) == CUSPARSE_STATUS_SUCCESS)
+                {
+                    int bs = 0;
+                    if
+                    (
+                        cusparseDcsrilu02_bufferSize
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            iluInfo, &bs
+                        ) == CUSPARSE_STATUS_SUCCESS
+                     && (bs == 0 || cudaMalloc(&iluBuf, bs) == cudaSuccess)
+                     && cusparseDcsrilu02_analysis
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            iluInfo, CUSPARSE_SOLVE_POLICY_NO_LEVEL,
+                            iluBuf
+                        ) == CUSPARSE_STATUS_SUCCESS
+                     && cusparseDcsrilu02
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            iluInfo, CUSPARSE_SOLVE_POLICY_NO_LEVEL,
+                            iluBuf
+                        ) == CUSPARSE_STATUS_SUCCESS
+                    )
+                    {
+                        if
+                        (
+                            cusparseCreateCsr(&matL, rows, rows, nnz, d_rowPtr, d_colInd, d_iluVals,
+                                CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseCreateCsr(&matU, rows, rows, nnz, d_rowPtr, d_colInd, d_iluVals,
+                                CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseSpSV_createDescr(&spsvLowerIlu) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseSpSV_createDescr(&spsvUpperIlu) == CUSPARSE_STATUS_SUCCESS
+                        )
+                        {
+                            cusparseFillMode_t fillL = CUSPARSE_FILL_MODE_LOWER;
+                            cusparseDiagType_t diagL = CUSPARSE_DIAG_TYPE_UNIT;
+                            cusparseSpMatSetAttribute(matL, CUSPARSE_SPMAT_FILL_MODE, &fillL, sizeof(fillL));
+                            cusparseSpMatSetAttribute(matL, CUSPARSE_SPMAT_DIAG_TYPE, &diagL, sizeof(diagL));
+                            cusparseFillMode_t fillU = CUSPARSE_FILL_MODE_UPPER;
+                            cusparseDiagType_t diagU = CUSPARSE_DIAG_TYPE_NON_UNIT;
+                            cusparseSpMatSetAttribute(matU, CUSPARSE_SPMAT_FILL_MODE, &fillU, sizeof(fillU));
+                            cusparseSpMatSetAttribute(matU, CUSPARSE_SPMAT_DIAG_TYPE, &diagU, sizeof(diagU));
+
+                            const double oneD = 1.0; size_t bL=0, bU=0;
+                            if
+                            (
+                                cusparseSpSV_bufferSize
+                                (
+                                    cusparseHandle,
+                                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                    &oneD,
+                                    matL,
+                                    preIn,
+                                    preOut,
+                                    CUDA_R_64F,
+                                    CUSPARSE_SPSV_ALG_DEFAULT,
+                                    spsvLowerIlu,
+                                    &bL
+                                ) == CUSPARSE_STATUS_SUCCESS
+                             && cusparseSpSV_bufferSize
+                                (
+                                    cusparseHandle,
+                                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                    &oneD,
+                                    matU,
+                                    preIn,
+                                    preOut,
+                                    CUDA_R_64F,
+                                    CUSPARSE_SPSV_ALG_DEFAULT,
+                                    spsvUpperIlu,
+                                    &bU
+                                ) == CUSPARSE_STATUS_SUCCESS
+                            )
+                            {
+                                iluBufSize = std::max(iluBufSize, std::max(bL, bU));
+                                if ((iluBufSize == 0) || (cudaMalloc(&iluBuf, iluBufSize) == cudaSuccess))
+                                {
+                                    if
+                                    (
+                                        cusparseSpSV_analysis
+                                        (
+                                            cusparseHandle,
+                                            CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                            &oneD,
+                                            matL,
+                                            preIn,
+                                            preOut,
+                                            CUDA_R_64F,
+                                            CUSPARSE_SPSV_ALG_DEFAULT,
+                                            spsvLowerIlu,
+                                            iluBuf
+                                        ) == CUSPARSE_STATUS_SUCCESS
+                                     && cusparseSpSV_analysis
+                                        (
+                                            cusparseHandle,
+                                            CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                            &oneD,
+                                            matU,
+                                            preIn,
+                                            preOut,
+                                            CUDA_R_64F,
+                                            CUSPARSE_SPSV_ALG_DEFAULT,
+                                            spsvUpperIlu,
+                                            iluBuf
+                                        ) == CUSPARSE_STATUS_SUCCESS
+                                    )
+                                    {
+                                        iluReady = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        iluDisableReason = std::string("csrilu02");
+                    }
+                }
+                else
+                {
+                    iluDisableReason = std::string("createInfo");
+                }
+            }
+            else if (useIC)
+            {
+                if (cusparseCreateCsric02Info(&icInfo) == CUSPARSE_STATUS_SUCCESS)
+                {
+                    int bs = 0;
+                    if
+                    (
+                        cusparseDcsric02_bufferSize
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            icInfo, &bs
+                        ) == CUSPARSE_STATUS_SUCCESS
+                     && (bs == 0 || cudaMalloc(&iluBuf, bs) == cudaSuccess)
+                     && cusparseDcsric02_analysis
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            icInfo, CUSPARSE_SOLVE_POLICY_NO_LEVEL,
+                            iluBuf
+                        ) == CUSPARSE_STATUS_SUCCESS
+                     && cusparseDcsric02
+                        (
+                            cusparseHandle, rows, nnz,
+                            iluDescr,
+                            reinterpret_cast<double*>(d_iluVals),
+                            d_rowPtr, d_colInd,
+                            icInfo, CUSPARSE_SOLVE_POLICY_NO_LEVEL,
+                            iluBuf
+                        ) == CUSPARSE_STATUS_SUCCESS
+                    )
+                    {
+                        if
+                        (
+                            cusparseCreateCsr(&matLchol, rows, rows, nnz, d_rowPtr, d_colInd, d_iluVals,
+                                CUSPARSE_INDEX_32I, CUSPARSE_INDEX_32I, CUSPARSE_INDEX_BASE_ZERO, CUDA_R_64F) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseSpSV_createDescr(&spsvLowerChol) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseSpSV_createDescr(&spsvUpperTChol) == CUSPARSE_STATUS_SUCCESS
+                        )
+                        {
+                            cusparseFillMode_t fillL = CUSPARSE_FILL_MODE_LOWER;
+                            cusparseDiagType_t diagType = CUSPARSE_DIAG_TYPE_NON_UNIT;
+                            cusparseSpMatSetAttribute(matLchol, CUSPARSE_SPMAT_FILL_MODE, &fillL, sizeof(fillL));
+                            cusparseSpMatSetAttribute(matLchol, CUSPARSE_SPMAT_DIAG_TYPE, &diagType, sizeof(diagType));
+
+                            const double oneD = 1.0; size_t bL=0, bUT=0;
+                            if
+                            (
+                                cusparseSpSV_bufferSize
+                                (
+                                    cusparseHandle,
+                                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                    &oneD,
+                                    matLchol,
+                                    preIn,
+                                    preOut,
+                                    CUDA_R_64F,
+                                    CUSPARSE_SPSV_ALG_DEFAULT,
+                                    spsvLowerChol,
+                                    &bL
+                                ) == CUSPARSE_STATUS_SUCCESS
+                             && cusparseSpSV_bufferSize
+                                (
+                                    cusparseHandle,
+                                    CUSPARSE_OPERATION_TRANSPOSE,
+                                    &oneD,
+                                    matLchol,
+                                    preIn,
+                                    preOut,
+                                    CUDA_R_64F,
+                                    CUSPARSE_SPSV_ALG_DEFAULT,
+                                    spsvUpperTChol,
+                                    &bUT
+                                ) == CUSPARSE_STATUS_SUCCESS
+                            )
+                            {
+                                iluBufSize = std::max(iluBufSize, std::max(bL, bUT));
+                                if ((iluBufSize == 0) || (cudaMalloc(&iluBuf, iluBufSize) == cudaSuccess))
+                                {
+                                    if
+                                    (
+                                        cusparseSpSV_analysis
+                                        (
+                                            cusparseHandle,
+                                            CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                            &oneD,
+                                            matLchol,
+                                            preIn,
+                                            preOut,
+                                            CUDA_R_64F,
+                                            CUSPARSE_SPSV_ALG_DEFAULT,
+                                            spsvLowerChol,
+                                            iluBuf
+                                        ) == CUSPARSE_STATUS_SUCCESS
+                                     && cusparseSpSV_analysis
+                                        (
+                                            cusparseHandle,
+                                            CUSPARSE_OPERATION_TRANSPOSE,
+                                            &oneD,
+                                            matLchol,
+                                            preIn,
+                                            preOut,
+                                            CUDA_R_64F,
+                                            CUSPARSE_SPSV_ALG_DEFAULT,
+                                            spsvUpperTChol,
+                                            iluBuf
+                                        ) == CUSPARSE_STATUS_SUCCESS
+                                    )
+                                    {
+                                        icReady = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        iluDisableReason = std::string("csric02");
+                    }
+                }
+                else
+                {
+                    iluDisableReason = std::string("createInfo");
+                }
+            }
         }
     }
 
@@ -1898,6 +2229,112 @@ using DeviceScalar = double;
             // No descriptor state to restore when using transient DnVecs
             return true;
         }
+        else if (icReady)
+        {
+            // Incomplete Cholesky: solve L y = rhs; solve L^T out = y
+            const double oneD = 1.0;
+            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("ICCopyFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, out);
+            cusparseDnVecSetValues(preOut, d_preTmp);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &oneD,
+                    matLchol,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvLowerChol
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ICLowerFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, d_preTmp);
+            cusparseDnVecSetValues(preOut, out);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_TRANSPOSE,
+                    &oneD,
+                    matLchol,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvUpperTChol
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ICUpperTFail");
+                return false;
+            }
+            return true;
+        }
+        else if (iluReady)
+        {
+            // ILU0: solve L y = rhs; solve U out = y
+            const double oneD = 1.0;
+            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("ILUCopyFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, out);
+            cusparseDnVecSetValues(preOut, d_preTmp);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &oneD,
+                    matL,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvLowerIlu
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ILULowerFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, d_preTmp);
+            cusparseDnVecSetValues(preOut, out);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &oneD,
+                    matU,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvUpperIlu
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ILUUpperFail");
+                return false;
+            }
+            return true;
+        }
         else if (sgsReady)
         {
             // out = M^{-1} rhs via SGS: solve (D+L) y = rhs; solve (D+L)^T out = y
@@ -1999,6 +2436,23 @@ using DeviceScalar = double;
             Info<< "cudaPCG(" << fieldName_ << "): SGS preconditioner disabled ("
                 << (sgsDisableReason.size() ? sgsDisableReason : std::string("buildFailure"))
                 << ")" << nl;
+        }
+    }
+    if (reportStats && (useILU || useIC))
+    {
+        if (useILU)
+        {
+            Info<< "cudaPCG(" << fieldName_ << "): ILU0 preconditioner "
+                << (iluReady ? "active" : "disabled")
+                << (iluReady ? "" : (std::string(" (") + (iluDisableReason.size()?iluDisableReason:"buildFailure") + ")"))
+                << nl;
+        }
+        if (useIC)
+        {
+            Info<< "cudaPCG(" << fieldName_ << "): IC0 preconditioner "
+                << (icReady ? "active" : "disabled")
+                << (icReady ? "" : (std::string(" (") + (iluDisableReason.size()?iluDisableReason:"buildFailure") + ")"))
+                << nl;
         }
     }
 

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -18,6 +18,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #ifdef FOAM_USE_CUDA
 #include <cuda_runtime.h>
@@ -586,6 +587,10 @@ bool Foam::cudaPCG::gpuSolve
     const label cudaGraphWarmup =
         std::max<label>(0, controlDict_.lookupOrDefault<label>("cudaGraphWarmup", 5));
 
+    const Switch iterStatsSwitch =
+        controlDict_.lookupOrDefault<Switch>("logIterationStats", Switch(false));
+    const bool logIterationStats = bool(iterStatsSwitch);
+
     const label residualLogEvery =
         std::max<label>(1, controlDict_.lookupOrDefault<label>("residualLogEvery", 1));
 
@@ -636,6 +641,11 @@ bool Foam::cudaPCG::gpuSolve
     cudaGraphExec_t spmvGraphExec = nullptr;
     bool spmvGraphReady = false;
 
+    double setupTimeSeconds = 0.0;
+    double iterationAccumSeconds = 0.0;
+    double iterationMaxSeconds = 0.0;
+    label iterationCountStats = 0;
+
     cudaError_t cudaCode = cudaSetDevice(deviceId);
     if (cudaCode != cudaSuccess)
     {
@@ -652,7 +662,7 @@ bool Foam::cudaPCG::gpuSolve
 
     static_assert(sizeof(scalar) == sizeof(double), "cudaPCG currently requires double precision build");
 
-    using DeviceScalar = double;
+using DeviceScalar = double;
 
     const int rows = static_cast<int>(csrMatrix.nRows);
     const int nnz = static_cast<int>(csrMatrix.nnz);
@@ -2033,6 +2043,12 @@ bool Foam::cudaPCG::gpuSolve
     }
 
     // r = b - A*x
+    std::chrono::steady_clock::time_point setupStart;
+    if (logIterationStats)
+    {
+        setupStart = std::chrono::steady_clock::now();
+    }
+
     if
     (
         cusparseSpMV
@@ -2055,6 +2071,10 @@ bool Foam::cudaPCG::gpuSolve
     if (!syncStream())
     {
         return false;
+    }
+    if (logIterationStats)
+    {
+        setupTimeSeconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - setupStart).count();
     }
 
     if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_b), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
@@ -2132,6 +2152,11 @@ bool Foam::cudaPCG::gpuSolve
      || iter < minIter_
     )
     {
+        std::chrono::steady_clock::time_point iterStart;
+        if (logIterationStats)
+        {
+            iterStart = std::chrono::steady_clock::now();
+        }
         if (cusparseDnVecSetValues(vecX, d_p) != CUSPARSE_STATUS_SUCCESS)
         {
             return fail("cusparseSetVec(p)");
@@ -2332,6 +2357,17 @@ bool Foam::cudaPCG::gpuSolve
                 return fail("cublas axpy p+=z");
             }
         }
+
+        if (logIterationStats)
+        {
+            const double iterSeconds = std::chrono::duration<double>(std::chrono::steady_clock::now() - iterStart).count();
+            iterationAccumSeconds += iterSeconds;
+            if (iterSeconds > iterationMaxSeconds)
+            {
+                iterationMaxSeconds = iterSeconds;
+            }
+            ++iterationCountStats;
+        }
     }
 
     cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
@@ -2349,6 +2385,14 @@ bool Foam::cudaPCG::gpuSolve
         }
     }
     writeTelemetry(true, word::null);
+    if (logIterationStats && Pstream::master())
+    {
+        double avgIterSeconds = iterationCountStats > 0 ? iterationAccumSeconds/static_cast<double>(iterationCountStats) : 0.0;
+        Info<< "cudaPCG(" << fieldName_ << "): timing setup=" << setupTimeSeconds
+            << " s, iterations=" << iterationCountStats
+            << ", avgIter=" << avgIterSeconds << " s"
+            << ", maxIter=" << iterationMaxSeconds << " s" << nl;
+    }
     return true;
 }
 

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -4,12 +4,25 @@
 #include "Switch.H"
 #include "List.H"
 #include "PstreamReduceOps.H"
+#include "DynamicList.H"
+#include "OFstream.H"
+#include "OSspecific.H"
+#include "Pstream.H"
+#include "Time.H"
 
 #include <algorithm>
+#include <cmath>
+#include <ios>
 #include <limits>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #ifdef FOAM_USE_CUDA
 #include <cuda_runtime.h>
+#include <cuda.h>
+#include <nvrtc.h>
 #define CUSPARSE_USE_DEPRECATED_API
 #include <cusparse_v2.h>
 #include <cusparse.h>
@@ -32,6 +45,374 @@ inline std::string toLower(const std::string& s)
     std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c){ return std::tolower(c); });
     return out;
 }
+
+#ifdef FOAM_USE_CUDA
+
+inline const char* cuStatusName(CUresult code)
+{
+    const char* name = nullptr;
+    if (code == CUDA_SUCCESS)
+    {
+        return "CUDA_SUCCESS";
+    }
+    if (cuGetErrorName(code, &name) != CUDA_SUCCESS || !name)
+    {
+        return "CUDA_ERROR_UNKNOWN";
+    }
+    return name;
+}
+
+inline const char* nvrtcStatusName(nvrtcResult code)
+{
+    return nvrtcGetErrorString(code);
+}
+
+static const char* colouredKernelSource = R"(
+#include <cuda_runtime.h>
+#include <math_functions.h>
+
+extern "C" __global__
+void colouredForwardSweep(
+    int count,
+    const int* __restrict__ rowIndices,
+    const int* __restrict__ rowPtr,
+    const int* __restrict__ colInd,
+    const double* __restrict__ values,
+    const int* __restrict__ colours,
+    const double* __restrict__ rhs,
+    double* __restrict__ x,
+    int colourId,
+    double omega,
+    double diagFloor,
+    int* __restrict__ failFlag
+)
+{
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= count)
+    {
+        return;
+    }
+
+    const int row = rowIndices[tid];
+    double sum = rhs[row];
+    double diag = 0.0;
+
+    for (int k = rowPtr[row]; k < rowPtr[row + 1]; ++k)
+    {
+        const int col = colInd[k];
+        const double val = values[k];
+        if (col == row)
+        {
+            diag = val;
+        }
+        else if (colours[col] < colourId)
+        {
+            sum -= val * x[col];
+        }
+    }
+
+    if (fabs(diag) <= diagFloor)
+    {
+        atomicMax(failFlag, 1);
+        return;
+    }
+
+    const double newVal = sum / diag;
+    const double oldVal = x[row];
+    const double updated = oldVal + omega * (newVal - oldVal);
+    if (!isfinite(updated))
+    {
+        atomicMax(failFlag, 2);
+    }
+    x[row] = updated;
+}
+
+extern "C" __global__
+void colouredBackwardSweep(
+    int count,
+    const int* __restrict__ rowIndices,
+    const int* __restrict__ rowPtr,
+    const int* __restrict__ colInd,
+    const double* __restrict__ values,
+    const int* __restrict__ colours,
+    const double* __restrict__ rhs,
+    double* __restrict__ x,
+    int colourId,
+    double omega,
+    double diagFloor,
+    int* __restrict__ failFlag
+)
+{
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (tid >= count)
+    {
+        return;
+    }
+
+    const int row = rowIndices[tid];
+    double sum = rhs[row];
+    double diag = 0.0;
+
+    for (int k = rowPtr[row]; k < rowPtr[row + 1]; ++k)
+    {
+        const int col = colInd[k];
+        const double val = values[k];
+        if (col == row)
+        {
+            diag = val;
+        }
+        else if (colours[col] > colourId)
+        {
+            sum -= val * x[col];
+        }
+    }
+
+    if (fabs(diag) <= diagFloor)
+    {
+        atomicMax(failFlag, 1);
+        return;
+    }
+
+    const double newVal = sum / diag;
+    const double oldVal = x[row];
+    const double updated = oldVal + omega * (newVal - oldVal);
+    if (!isfinite(updated))
+    {
+        atomicMax(failFlag, 2);
+    }
+    x[row] = updated;
+}
+)";
+
+struct ColourKernelCacheEntry
+{
+    int major;
+    int minor;
+    CUmodule module;
+    CUfunction forward;
+    CUfunction backward;
+    bool ok;
+};
+
+static std::mutex colourKernelMutex;
+static std::vector<ColourKernelCacheEntry> colourKernelCache;
+static std::once_flag driverInitFlag;
+static CUresult driverInitStatus = CUDA_SUCCESS;
+
+inline bool ensureDriverInitialised()
+{
+    std::call_once
+    (
+        driverInitFlag,
+        []()
+        {
+            driverInitStatus = cuInit(0);
+        }
+    );
+
+    return driverInitStatus == CUDA_SUCCESS;
+}
+
+bool compileColourKernels
+(
+    const cudaDeviceProp& prop,
+    ColourKernelCacheEntry& entry,
+    bool verbose
+)
+{
+    entry.major = prop.major;
+    entry.minor = prop.minor;
+    entry.module = nullptr;
+    entry.forward = nullptr;
+    entry.backward = nullptr;
+    entry.ok = false;
+
+    if (!ensureDriverInitialised())
+    {
+        if (verbose)
+        {
+            WarningInFunction << "cuInit failed: " << cuStatusName(driverInitStatus) << Foam::endl;
+        }
+        return false;
+    }
+
+    nvrtcProgram prog = nullptr;
+    nvrtcResult nvRes =
+        nvrtcCreateProgram
+        (
+            &prog,
+            colouredKernelSource,
+            "colouredPreconditioner.cu",
+            0,
+            nullptr,
+            nullptr
+        );
+
+    if (nvRes != NVRTC_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "nvrtcCreateProgram failed: " << nvrtcStatusName(nvRes) << Foam::endl;
+        }
+        return false;
+    }
+
+    std::ostringstream archOpt;
+    archOpt << "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = archOpt.str();
+
+    std::vector<const char*> compileOptions;
+    compileOptions.push_back(archStr.c_str());
+    compileOptions.push_back("--fmad=false");
+    compileOptions.push_back("--std=c++14");
+    compileOptions.push_back("-I/usr/include");
+    compileOptions.push_back("-I/usr/local/cuda/include");
+    compileOptions.push_back("-I/usr/include/x86_64-linux-gnu");
+
+    nvRes = nvrtcCompileProgram
+    (
+        prog,
+        static_cast<int>(compileOptions.size()),
+        compileOptions.data()
+    );
+
+    if (nvRes != NVRTC_SUCCESS)
+    {
+        if (verbose)
+        {
+            size_t logSize = 0;
+            nvrtcGetProgramLogSize(prog, &logSize);
+            std::string log(logSize, '\0');
+            nvrtcGetProgramLog(prog, &log[0]);
+            WarningInFunction
+                << "nvrtcCompileProgram failed (" << nvrtcStatusName(nvRes) << "):"
+                << Foam::nl << log.c_str() << Foam::endl;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvRes = nvrtcGetPTXSize(prog, &ptxSize);
+    if (nvRes != NVRTC_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "nvrtcGetPTXSize failed: " << nvrtcStatusName(nvRes) << Foam::endl;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    std::string ptx(ptxSize, '\0');
+    nvRes = nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+    if (nvRes != NVRTC_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "nvrtcGetPTX failed: " << nvrtcStatusName(nvRes) << Foam::endl;
+        }
+        return false;
+    }
+
+    CUresult cuRes =
+        cuModuleLoadDataEx
+        (
+            &entry.module,
+            static_cast<const void*>(ptx.data()),
+            0,
+            nullptr,
+            nullptr
+        );
+
+    if (cuRes != CUDA_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "cuModuleLoadDataEx failed: " << cuStatusName(cuRes) << Foam::endl;
+        }
+        entry.module = nullptr;
+        return false;
+    }
+
+    cuRes = cuModuleGetFunction(&entry.forward, entry.module, "colouredForwardSweep");
+    if (cuRes != CUDA_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "cuModuleGetFunction forward failed: " << cuStatusName(cuRes) << Foam::endl;
+        }
+        cuModuleUnload(entry.module);
+        entry.module = nullptr;
+        return false;
+    }
+
+    cuRes = cuModuleGetFunction(&entry.backward, entry.module, "colouredBackwardSweep");
+    if (cuRes != CUDA_SUCCESS)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "cuModuleGetFunction backward failed: " << cuStatusName(cuRes) << Foam::endl;
+        }
+        cuModuleUnload(entry.module);
+        entry.module = nullptr;
+        entry.forward = nullptr;
+        return false;
+    }
+
+    entry.ok = true;
+    return true;
+}
+
+bool getColourKernels
+(
+    const int deviceId,
+    CUfunction& forward,
+    CUfunction& backward,
+    bool verbose
+)
+{
+    std::lock_guard<std::mutex> guard(colourKernelMutex);
+
+    cudaDeviceProp prop;
+    if (cudaGetDeviceProperties(&prop, deviceId) != cudaSuccess)
+    {
+        if (verbose)
+        {
+            WarningInFunction << "cudaGetDeviceProperties failed for device " << deviceId << Foam::endl;
+        }
+        return false;
+    }
+
+    for (const ColourKernelCacheEntry& entry : colourKernelCache)
+    {
+        if (entry.major == prop.major && entry.minor == prop.minor)
+        {
+            if (entry.ok)
+            {
+                forward = entry.forward;
+                backward = entry.backward;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    ColourKernelCacheEntry entry;
+    if (compileColourKernels(prop, entry, verbose))
+    {
+        forward = entry.forward;
+        backward = entry.backward;
+        colourKernelCache.push_back(entry);
+        return true;
+    }
+
+    colourKernelCache.push_back(entry);
+    return false;
+}
+
+#endif // FOAM_USE_CUDA
 }
 
 Foam::cudaPCG::cudaPCG
@@ -191,6 +572,70 @@ bool Foam::cudaPCG::gpuSolve
     const bool reportStats =
         controlDict_.lookupOrDefault<Switch>("reportGpuStats", Switch(false));
 
+    const Switch logResidualTrajectorySwitch =
+        controlDict_.lookupOrDefault<Switch>("logResidualTrajectory", Switch(false));
+    const bool logResidualTrajectory = bool(logResidualTrajectorySwitch);
+
+    const Switch pipelinedSwitch =
+        controlDict_.lookupOrDefault<Switch>("usePipelinedCG", Switch(false));
+    const bool usePipelinedCG = bool(pipelinedSwitch);
+
+    const Switch cudaGraphSwitch =
+        controlDict_.lookupOrDefault<Switch>("useCudaGraph", Switch(false));
+    const bool useCudaGraph = bool(cudaGraphSwitch);
+    const label cudaGraphWarmup =
+        std::max<label>(0, controlDict_.lookupOrDefault<label>("cudaGraphWarmup", 5));
+
+    const label residualLogEvery =
+        std::max<label>(1, controlDict_.lookupOrDefault<label>("residualLogEvery", 1));
+
+    fileName residualLogFile =
+        controlDict_.lookupOrDefault<fileName>("residualLogFile", fileName::null);
+
+    const Switch logColourStatsSwitch =
+        controlDict_.lookupOrDefault<Switch>("logColourStats", Switch(reportStats));
+    const bool logColourStats = bool(logColourStatsSwitch);
+
+    fileName colourStatsFile =
+        controlDict_.lookupOrDefault<fileName>("colourStatsFile", fileName::null);
+
+    if (logResidualTrajectory && residualLogFile == fileName::null)
+    {
+        residualLogFile =
+            fileName("postProcessing/cudaPCG/" + fieldName_ + "_residual.csv");
+    }
+
+    if ((logColourStats || reportStats) && colourStatsFile == fileName::null)
+    {
+        colourStatsFile =
+            fileName("postProcessing/cudaPCG/" + fieldName_ + "_colour.csv");
+    }
+
+    std::vector<label> residualIterHistory;
+    std::vector<scalar> residualValueHistory;
+    if (logResidualTrajectory)
+    {
+        residualIterHistory.reserve(maxIter_ + 2);
+        residualValueHistory.reserve(maxIter_ + 2);
+    }
+
+    bool telemetryWritten = false;
+    bool colourInitiallyRequested = false;
+    bool colourBuiltSuccessfully = false;
+    bool colourAppliedSuccessfully = false;
+    label colourSetCount = 0;
+    label colourMinSize = 0;
+    label colourMaxSize = 0;
+    scalar colourAvgSize = 0;
+    label colourDisableCount = 0;
+    std::vector<std::string> colourDisableEvents;
+    bool colourFallbackTriggered = false;
+
+    cudaStream_t computeStream = nullptr;
+    cudaGraph_t spmvGraph = nullptr;
+    cudaGraphExec_t spmvGraphExec = nullptr;
+    bool spmvGraphReady = false;
+
     cudaError_t cudaCode = cudaSetDevice(deviceId);
     if (cudaCode != cudaSuccess)
     {
@@ -203,20 +648,6 @@ bool Foam::cudaPCG::gpuSolve
     {
         message = "CSR row mismatch";
         return false;
-    }
-
-    if (reportStats)
-    {
-        const scalarField& diag = matrix_.diag();
-        scalar minDiag = std::numeric_limits<scalar>::max();
-        scalar maxDiag = -std::numeric_limits<scalar>::max();
-        for (const scalar d : diag)
-        {
-            minDiag = std::min(minDiag, d);
-            maxDiag = std::max(maxDiag, d);
-        }
-        Info<< "cudaPCG: diagonal range [" << minDiag << ", " << maxDiag << "]"
-            << nl;
     }
 
     static_assert(sizeof(scalar) == sizeof(double), "cudaPCG currently requires double precision build");
@@ -238,6 +669,20 @@ bool Foam::cudaPCG::gpuSolve
     }
 
     const scalarField& diag = matrix_.diag();
+    scalar minDiag = std::numeric_limits<scalar>::max();
+    scalar maxDiag = -std::numeric_limits<scalar>::max();
+    for (const scalar d : diag)
+    {
+        minDiag = std::min(minDiag, d);
+        maxDiag = std::max(maxDiag, d);
+    }
+
+    if (reportStats)
+    {
+        Info<< "cudaPCG: diagonal range [" << minDiag << ", " << maxDiag << "]"
+            << nl;
+    }
+
     List<DeviceScalar> diagInv(diag.size());
     forAll(diag, i)
     {
@@ -249,14 +694,76 @@ bool Foam::cudaPCG::gpuSolve
     DeviceScalar *d_r=nullptr, *d_p=nullptr, *d_Ap=nullptr;
     DeviceScalar *d_z=nullptr, *d_diagInv=nullptr;
     int *d_rowPtr=nullptr, *d_colInd=nullptr;
+    int *d_colors=nullptr, *d_colorIndices=nullptr;
+    int *d_failFlag=nullptr;
 
-    // Optional SGS preconditioner (D+L) solves
+    // Preconditioner configuration
+    const word preconditionerWord = controlDict_.lookupOrDefault<word>("preconditioner", word("diagonal"));
+    const std::string precondLower = toLower(preconditionerWord);
+
+    bool useColour = false;
     bool useSGS = false;
+
+    if
+    (
+        precondLower == "colour"
+     || precondLower == "coloured"
+     || precondLower == "colored"
+     || precondLower == "multicolour"
+     || precondLower == "multicolor"
+     || precondLower == "colorgs"
+     || precondLower == "colourgs"
+    )
     {
-        const word precName = controlDict_.lookupOrDefault<word>("preconditioner", word("diagonal"));
-        const std::string pl = toLower(precName);
-        useSGS = (pl == "sgs" || pl == "symgaussseidel" || pl == "ic" || pl == "dic");
+        useColour = true;
     }
+    else if
+    (
+        precondLower == "sgs"
+     || precondLower == "symgaussseidel"
+     || precondLower == "ic"
+     || precondLower == "dic"
+    )
+    {
+        useSGS = true;
+    }
+
+    colourInitiallyRequested = useColour;
+
+    label polySweepsCfg = controlDict_.lookupOrDefault<label>("polyJacobiSweeps", 0);
+    scalar jacOmegaCfg = controlDict_.lookupOrDefault<scalar>("jacobiOmega", scalar(0.7));
+    const Switch polyAuto = controlDict_.lookupOrDefault<Switch>("polyJacobiAuto", Switch(true));
+    bool usePolyJacobi = (!useColour && !useSGS) && ((polySweepsCfg > 0) || polyAuto);
+    label polySweepsEff = polySweepsCfg;
+    double jacOmegaEff = static_cast<double>(jacOmegaCfg);
+
+    const scalar colourOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourOmega", scalar(0.65));
+    const scalar colourBackwardOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourBackwardOmega", scalar(0.85));
+    const scalar colourDiagFloorCfg = controlDict_.lookupOrDefault<scalar>("colourDiagFloor", scalar(1e-12));
+    const label colourBlockSizeCfg =
+        std::max<label>
+        (
+            32,
+            std::min<label>(1024, controlDict_.lookupOrDefault<label>("colourBlockSize", 128))
+        );
+    const bool colourVerbose =
+        controlDict_.lookupOrDefault<Switch>("colourVerbose", Switch(false));
+
+    const double colourOmegaEff = std::max(0.0, std::min(1.0, static_cast<double>(colourOmegaCfg)));
+    const double colourBackwardOmegaEff = std::max(0.0, std::min(1.0, static_cast<double>(colourBackwardOmegaCfg)));
+    const double colourDiagFloor = std::max(1e-30, static_cast<double>(colourDiagFloorCfg));
+    const int colourBlockSize = static_cast<int>(colourBlockSizeCfg);
+
+    cudaPCGDetail::Colouring colouring;
+    List<int> colourPtrHost;
+    List<int> colourIndicesHost;
+    List<int> colourOfRowHost;
+    label nColourSets = 0;
+    bool colourReady = false;
+    bool colourOperational = false;
+    CUfunction colourForwardKernel = nullptr;
+    CUfunction colourBackwardKernel = nullptr;
+
     int *d_preRowPtr=nullptr, *d_preColInd=nullptr;
     DeviceScalar *d_preVals=nullptr, *d_preTmp=nullptr, *d_preTmp2=nullptr;
     cusparseSpMatDescr_t matDL = nullptr; // (D+L)
@@ -270,6 +777,246 @@ bool Foam::cudaPCG::gpuSolve
     cusparseDnVecDescr_t vecX = nullptr;
     cusparseDnVecDescr_t vecY = nullptr;
     void* spmvBuffer = nullptr;
+
+    if (useColour)
+    {
+        colouring = cudaPCGDetail::buildGreedyColouring(matrix_);
+        nColourSets = colouring.nColours;
+
+        const bool validColouring =
+        (
+            nColourSets > 0
+         && colouring.colourPtr.size() == static_cast<label>(nColourSets + 1)
+         && colouring.colourIndices.size() == csrMatrix.nRows
+         && colouring.cellToColour.size() == csrMatrix.nRows
+        );
+
+        if (!validColouring)
+        {
+            if (colourVerbose || reportStats)
+            {
+                Info
+                    << "cudaPCG: disabling coloured preconditioner (colouring invalid)"
+                    << nl;
+            }
+            colourFallbackTriggered = true;
+            ++colourDisableCount;
+            colourDisableEvents.push_back("invalidColouring");
+            useColour = false;
+        }
+        else
+        {
+            colourPtrHost.setSize(nColourSets + 1);
+            colourIndicesHost.setSize(rows);
+            colourOfRowHost.setSize(rows);
+
+            for (label i = 0; i <= nColourSets; ++i)
+            {
+                colourPtrHost[i] = static_cast<int>(colouring.colourPtr[i]);
+            }
+            for (int i = 0; i < rows; ++i)
+            {
+                colourIndicesHost[i] = static_cast<int>(colouring.colourIndices[i]);
+                colourOfRowHost[i] = static_cast<int>(colouring.cellToColour[i]);
+            }
+
+            colourReady = true;
+            colourOperational = true;
+            colourBuiltSuccessfully = true;
+            colourSetCount = nColourSets;
+
+            if (nColourSets > 0)
+            {
+                label minColourSizeLocal = std::numeric_limits<label>::max();
+                label maxColourSizeLocal = 0;
+                scalar sumColourSize = 0;
+                for (label colourI = 0; colourI < nColourSets; ++colourI)
+                {
+                    const label size =
+                        colourPtrHost[colourI + 1] - colourPtrHost[colourI];
+                    minColourSizeLocal = min(minColourSizeLocal, size);
+                    maxColourSizeLocal = max(maxColourSizeLocal, size);
+                    sumColourSize += size;
+                }
+                colourMinSize = minColourSizeLocal;
+                colourMaxSize = maxColourSizeLocal;
+                colourAvgSize = sumColourSize/static_cast<scalar>(nColourSets);
+            }
+            else
+            {
+                colourMinSize = 0;
+                colourMaxSize = 0;
+                colourAvgSize = 0;
+            }
+
+            if (colourVerbose || reportStats)
+            {
+                Info<< "cudaPCG: coloured preconditioner using " << nColourSets << " colour sets" << nl;
+            }
+        }
+    }
+
+    auto disableColour = [&](const char* stage)
+    {
+        if (colourVerbose || reportStats)
+        {
+            Info<< "cudaPCG: coloured preconditioner disabled (" << stage << ')' << nl;
+        }
+        colourFallbackTriggered = true;
+        ++colourDisableCount;
+        colourDisableEvents.push_back(stage ? std::string(stage) : std::string("unspecified"));
+        if (d_colors)
+        {
+            cudaFree(d_colors);
+            d_colors = nullptr;
+        }
+        if (d_colorIndices)
+        {
+            cudaFree(d_colorIndices);
+            d_colorIndices = nullptr;
+        }
+        if (d_failFlag)
+        {
+            cudaFree(d_failFlag);
+            d_failFlag = nullptr;
+        }
+        colourReady = false;
+        colourOperational = false;
+        useColour = false;
+    };
+
+    auto writeTelemetry =
+        [&](const bool success, const word& failureMessage)
+    {
+        if (telemetryWritten)
+        {
+            return;
+        }
+        telemetryWritten = true;
+
+        const bool master = Pstream::master();
+        const Time& runTime = matrix_.mesh().thisDb().time();
+
+        auto resolvePath = [&](const fileName& fName) -> fileName
+        {
+            if (fName == fileName::null)
+            {
+                return fName;
+            }
+            if (fName.isAbsolute())
+            {
+                return fName;
+            }
+            return runTime.globalPath()/fName;
+        };
+
+        if (logResidualTrajectory && !residualValueHistory.empty() && master)
+        {
+            const fileName resolved = resolvePath(residualLogFile);
+            const fileName residualParent = resolved.path();
+            if (!residualParent.empty())
+            {
+                mkDir(residualParent);
+            }
+            OFstream os(resolved);
+            os.setf(std::ios::scientific);
+            os.precision(IOstream::defaultPrecision());
+            os<< "# cudaPCG residual trajectory for " << fieldName_ << nl;
+            os<< "# success," << (success ? "true" : "false") << nl;
+            if (failureMessage.size())
+            {
+                os<< "# failure," << failureMessage << nl;
+            }
+            os<< "iteration,residual" << nl;
+            for (std::size_t i = 0; i < residualValueHistory.size(); ++i)
+            {
+                os<< residualIterHistory[i] << ',' << residualValueHistory[i] << nl;
+            }
+            Info<< "cudaPCG(" << fieldName_ << "): residual log -> " << resolved << nl;
+        }
+
+        const bool colourActiveFinal = useColour && colourOperational;
+        const bool emitColourSummary =
+            colourInitiallyRequested && (reportStats || colourVerbose || logColourStats);
+        const bool masterHasColourData =
+            colourInitiallyRequested && master;
+
+        std::ostringstream disableSummary;
+        if (!colourDisableEvents.empty())
+        {
+            for (std::size_t i = 0; i < colourDisableEvents.size(); ++i)
+            {
+                if (i)
+                {
+                    disableSummary << '|';
+                }
+                disableSummary << colourDisableEvents[i];
+            }
+        }
+
+        if (emitColourSummary && master)
+        {
+            Info<< "cudaPCG(" << fieldName_ << "): colour sets=" << colourSetCount
+                << " size[min,max,avg]=[" << colourMinSize << ',' << colourMaxSize
+                << ',' << colourAvgSize << ']'
+                << " omegaF=" << colourOmegaEff
+                << " omegaB=" << colourBackwardOmegaEff
+                << " diagFloor=" << colourDiagFloor
+                << " built=" << (colourBuiltSuccessfully ? "true" : "false")
+                << " applied=" << (colourAppliedSuccessfully ? "true" : "false")
+                << " activeFinal=" << (colourActiveFinal ? "true" : "false")
+                << " disables=" << colourDisableCount;
+            if (colourFallbackTriggered)
+            {
+                Info<< " (fallback triggered)";
+            }
+            Info<< nl;
+            if (!colourDisableEvents.empty())
+            {
+                Info<< "cudaPCG(" << fieldName_ << "): colour disable history "
+                    << disableSummary.str() << nl;
+            }
+        }
+
+        if ((reportStats || logColourStats) && masterHasColourData)
+        {
+            const fileName resolved = resolvePath(colourStatsFile);
+            const fileName colourParent = resolved.path();
+            if (!colourParent.empty())
+            {
+                mkDir(colourParent);
+            }
+            OFstream os(resolved);
+            os.setf(std::ios::scientific);
+            os.precision(IOstream::defaultPrecision());
+            os<< "# cudaPCG colour statistics for " << fieldName_ << nl;
+            os<< "# success," << (success ? "true" : "false") << nl;
+            if (failureMessage.size())
+            {
+                os<< "# failure," << failureMessage << nl;
+            }
+            os<< "nColours,minSize,maxSize,avgSize,diagFloor,omegaForward,omegaBackward,diagMin,diagMax,built,applied,activeFinal,disableCount,disableStages" << nl;
+            os<< colourSetCount << ','
+               << colourMinSize << ','
+               << colourMaxSize << ','
+               << colourAvgSize << ','
+               << colourDiagFloor << ','
+               << colourOmegaEff << ','
+               << colourBackwardOmegaEff << ','
+               << minDiag << ','
+               << maxDiag << ','
+               << (colourBuiltSuccessfully ? 1 : 0) << ','
+               << (colourAppliedSuccessfully ? 1 : 0) << ','
+               << (colourActiveFinal ? 1 : 0) << ','
+               << colourDisableCount << ',';
+            if (!colourDisableEvents.empty())
+            {
+                os<< disableSummary.str();
+            }
+            os<< nl;
+            Info<< "cudaPCG(" << fieldName_ << "): colour stats -> " << resolved << nl;
+        }
+    };
 
     auto cleanup = [&]()
     {
@@ -313,6 +1060,9 @@ bool Foam::cudaPCG::gpuSolve
         if (d_diagInv) cudaFree(d_diagInv);
         if (d_rowPtr) cudaFree(d_rowPtr);
         if (d_colInd) cudaFree(d_colInd);
+        if (d_colors) cudaFree(d_colors);
+        if (d_colorIndices) cudaFree(d_colorIndices);
+        if (d_failFlag) cudaFree(d_failFlag);
         if (d_preRowPtr) cudaFree(d_preRowPtr);
         if (d_preColInd) cudaFree(d_preColInd);
         if (d_preVals) cudaFree(d_preVals);
@@ -324,13 +1074,44 @@ bool Foam::cudaPCG::gpuSolve
         if (spsvUpperT) cusparseSpSV_destroyDescr(spsvUpperT);
         if (spsvBuf) cudaFree(spsvBuf);
         if (d_preTmp2) cudaFree(d_preTmp2);
+        if (spmvGraphExec)
+        {
+            cudaGraphExecDestroy(spmvGraphExec);
+            spmvGraphExec = nullptr;
+        }
+        if (spmvGraph)
+        {
+            cudaGraphDestroy(spmvGraph);
+            spmvGraph = nullptr;
+        }
+        if (computeStream)
+        {
+            cudaStreamDestroy(computeStream);
+            computeStream = nullptr;
+        }
     };
 
     auto fail = [&](const word& msg)
     {
         cleanup();
         message = msg;
+        writeTelemetry(false, msg);
         return false;
+    };
+
+    auto syncStream = [&]() -> bool
+    {
+        if (!computeStream)
+        {
+            return true;
+        }
+        if (cudaStreamSynchronize(computeStream) != cudaSuccess)
+        {
+            message = word("cudaStreamSyncFail");
+            cleanup();
+            return false;
+        }
+        return true;
     };
 
     // Allocate
@@ -369,10 +1150,56 @@ bool Foam::cudaPCG::gpuSolve
     if (cudaMemcpy(d_diagInv, diagInv.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
         return fail("cudaMemcpy(diagInv)");
 
+    if (colourReady)
+    {
+        if (cudaMalloc(reinterpret_cast<void**>(&d_colors), sizeof(int)*rows) != cudaSuccess)
+        {
+            disableColour("cudaMalloc colours");
+        }
+        else if (cudaMalloc(reinterpret_cast<void**>(&d_colorIndices), sizeof(int)*rows) != cudaSuccess)
+        {
+            d_colorIndices = nullptr;
+            disableColour("cudaMalloc colourIndices");
+        }
+        else if (cudaMalloc(reinterpret_cast<void**>(&d_failFlag), sizeof(int)) != cudaSuccess)
+        {
+            d_failFlag = nullptr;
+            disableColour("cudaMalloc colourFlag");
+        }
+        else if
+        (
+            cudaMemcpy(d_colors, colourOfRowHost.begin(), sizeof(int)*rows, cudaMemcpyHostToDevice) != cudaSuccess
+         || cudaMemcpy(d_colorIndices, colourIndicesHost.begin(), sizeof(int)*rows, cudaMemcpyHostToDevice) != cudaSuccess
+        )
+        {
+            disableColour("cudaMemcpy colourData");
+        }
+        else if (!getColourKernels(deviceId, colourForwardKernel, colourBackwardKernel, colourVerbose || reportStats))
+        {
+            disableColour("kernelCompile");
+        }
+    }
+
     if (cusparseCreate(&cusparseHandle) != CUSPARSE_STATUS_SUCCESS)
         return fail("cusparseCreate");
     if (cublasCreate(&cublasHandle) != CUBLAS_STATUS_SUCCESS)
         return fail("cublasCreate");
+
+    if (usePipelinedCG || useCudaGraph)
+    {
+        if (cudaStreamCreateWithFlags(&computeStream, cudaStreamNonBlocking) != cudaSuccess)
+        {
+            return fail("cudaStreamCreate");
+        }
+        if (cublasSetStream(cublasHandle, computeStream) != CUBLAS_STATUS_SUCCESS)
+        {
+            return fail("cublasSetStream");
+        }
+        if (cusparseSetStream(cusparseHandle, computeStream) != CUSPARSE_STATUS_SUCCESS)
+        {
+            return fail("cusparseSetStream");
+        }
+    }
 
     if
     (
@@ -402,12 +1229,6 @@ bool Foam::cudaPCG::gpuSolve
 
     // Build optional SGS preconditioner structures: CSR of (D+L)
     bool sgsReady = false;
-    label polySweepsCfg = controlDict_.lookupOrDefault<label>("polyJacobiSweeps", 0);
-    scalar jacOmegaCfg = controlDict_.lookupOrDefault<scalar>("jacobiOmega", scalar(0.7));
-    const Switch polyAuto = controlDict_.lookupOrDefault<Switch>("polyJacobiAuto", Switch(true));
-    bool usePolyJacobi = (polySweepsCfg > 0) || polyAuto;
-    label polySweepsEff = polySweepsCfg;
-    double jacOmegaEff = static_cast<double>(jacOmegaCfg);
     int preRows = 0, preNnz = 0;
     if (useSGS)
     {
@@ -560,6 +1381,298 @@ bool Foam::cudaPCG::gpuSolve
         }
     }
 
+    if ((usePolyJacobi || useColour) && !d_preTmp)
+    {
+        if (cudaMalloc(reinterpret_cast<void**>(&d_preTmp), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        {
+            return fail("cudaMalloc(preTmp)");
+        }
+    }
+    if (usePolyJacobi && !d_preTmp2)
+    {
+        if (cudaMalloc(reinterpret_cast<void**>(&d_preTmp2), sizeof(DeviceScalar)*rows) != cudaSuccess)
+        {
+            return fail("cudaMalloc(preTmp2)");
+        }
+    }
+
+    auto applyDiagonalDevice =
+        [&](const double* rhsVec, double* outVec) -> bool
+    {
+        if (cublasDcopy(cublasHandle, rows, rhsVec, 1, outVec, 1) != CUBLAS_STATUS_SUCCESS)
+        {
+            message = word("DiagCopyFail");
+            return false;
+        }
+        if
+        (
+            cublasDdgmm
+            (
+                cublasHandle,
+                CUBLAS_SIDE_LEFT,
+                rows,
+                1,
+                outVec,
+                rows,
+                reinterpret_cast<const double*>(d_diagInv),
+                1,
+                outVec,
+                rows
+            ) != CUBLAS_STATUS_SUCCESS
+        )
+        {
+            message = word("DiagScaleFail");
+            return false;
+        }
+        return true;
+    };
+
+    auto applyColourDevice =
+        [&](const double* rhsVec, double* outVec, const char* stage) -> bool
+    {
+        (void)stage;
+        if (!colourOperational || !colourReady)
+        {
+            return false;
+        }
+        if (!d_preTmp || !d_colors || !d_colorIndices || !d_failFlag || !colourForwardKernel || !colourBackwardKernel)
+        {
+            disableColour("missingResources");
+            return false;
+        }
+
+        if (cudaMemset(d_preTmp, 0, sizeof(DeviceScalar)*rows) != cudaSuccess)
+        {
+            disableColour("zeroForward");
+            return false;
+        }
+        if (cudaMemset(outVec, 0, sizeof(DeviceScalar)*rows) != cudaSuccess)
+        {
+            disableColour("zeroResult");
+            return false;
+        }
+
+        int zeroFlag = 0;
+        if (cudaMemcpy(d_failFlag, &zeroFlag, sizeof(int), cudaMemcpyHostToDevice) != cudaSuccess)
+        {
+            disableColour("resetFlag");
+            return false;
+        }
+
+        const double diagFloorLocal = colourDiagFloor;
+        const double omegaForward = colourOmegaEff;
+        const double omegaBackward = colourBackwardOmegaEff;
+
+        for (label colour = 0; colour < nColourSets; ++colour)
+        {
+            const label start = colourPtrHost[colour];
+            const int count = static_cast<int>(colourPtrHost[colour+1] - start);
+            if (!count)
+            {
+                continue;
+            }
+
+            const int* rowIdxDev = d_colorIndices + start;
+            const int* rowPtrDev = d_rowPtr;
+            const int* colIndDev = d_colInd;
+            const double* valDev = reinterpret_cast<const double*>(d_vals);
+            const int* coloursDev = d_colors;
+            const double* rhsDev = rhsVec;
+            double* solDev = reinterpret_cast<double*>(d_preTmp);
+            int colourId = static_cast<int>(colour);
+            double omegaLocal = omegaForward;
+            double diagFloorPass = diagFloorLocal;
+            int* failDev = d_failFlag;
+
+            int countLocal = count;
+            void* args[] =
+            {
+                reinterpret_cast<void*>(&countLocal),
+                reinterpret_cast<void*>(&rowIdxDev),
+                reinterpret_cast<void*>(&rowPtrDev),
+                reinterpret_cast<void*>(&colIndDev),
+                reinterpret_cast<void*>(&valDev),
+                reinterpret_cast<void*>(&coloursDev),
+                reinterpret_cast<void*>(&rhsDev),
+                reinterpret_cast<void*>(&solDev),
+                reinterpret_cast<void*>(&colourId),
+                reinterpret_cast<void*>(&omegaLocal),
+                reinterpret_cast<void*>(&diagFloorPass),
+                reinterpret_cast<void*>(&failDev)
+            };
+
+            const int blocks = (count + colourBlockSize - 1)/colourBlockSize;
+            if (blocks <= 0)
+            {
+                continue;
+            }
+
+            CUresult launch =
+                cuLaunchKernel
+                (
+                    colourForwardKernel,
+                    blocks, 1, 1,
+                    colourBlockSize, 1, 1,
+                    0,
+                    nullptr,
+                    args,
+                    nullptr
+                );
+
+            if (launch != CUDA_SUCCESS)
+            {
+                disableColour("launchForward");
+                return false;
+            }
+
+            cudaError_t kernelErr = cudaGetLastError();
+            if (kernelErr != cudaSuccess)
+            {
+                disableColour("forwardKernel");
+                return false;
+            }
+        }
+
+        int failHost = 0;
+        if (cudaMemcpy(&failHost, d_failFlag, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+        {
+            disableColour("forwardFlag");
+            return false;
+        }
+        if (failHost != 0)
+        {
+            if (failHost == 1)
+            {
+                disableColour("forwardDiagFloor");
+            }
+            else if (failHost == 2)
+            {
+                disableColour("forwardNonFinite");
+            }
+            else
+            {
+                disableColour("forwardInstability");
+            }
+            return false;
+        }
+
+        if (cudaMemcpy(d_failFlag, &zeroFlag, sizeof(int), cudaMemcpyHostToDevice) != cudaSuccess)
+        {
+            disableColour("resetFlagBack");
+            return false;
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                outVec,
+                d_preTmp,
+                sizeof(DeviceScalar)*rows,
+                cudaMemcpyDeviceToDevice
+            ) != cudaSuccess
+        )
+        {
+            disableColour("prepBackward");
+            return false;
+        }
+
+        for (label colour = nColourSets; colour-- > 0; )
+        {
+            const label start = colourPtrHost[colour];
+            const int count = static_cast<int>(colourPtrHost[colour+1] - start);
+            if (!count)
+            {
+                continue;
+            }
+
+            const int* rowIdxDev = d_colorIndices + start;
+            const int* rowPtrDev = d_rowPtr;
+            const int* colIndDev = d_colInd;
+            const double* valDev = reinterpret_cast<const double*>(d_vals);
+            const int* coloursDev = d_colors;
+            const double* rhsDev = reinterpret_cast<const double*>(d_preTmp);
+            double* solDev = outVec;
+            int colourId = static_cast<int>(colour);
+            double omegaLocal = omegaBackward;
+            double diagFloorPass = diagFloorLocal;
+            int* failDev = d_failFlag;
+
+            int countLocal = count;
+            void* args[] =
+            {
+                reinterpret_cast<void*>(&countLocal),
+                reinterpret_cast<void*>(&rowIdxDev),
+                reinterpret_cast<void*>(&rowPtrDev),
+                reinterpret_cast<void*>(&colIndDev),
+                reinterpret_cast<void*>(&valDev),
+                reinterpret_cast<void*>(&coloursDev),
+                reinterpret_cast<void*>(&rhsDev),
+                reinterpret_cast<void*>(&solDev),
+                reinterpret_cast<void*>(&colourId),
+                reinterpret_cast<void*>(&omegaLocal),
+                reinterpret_cast<void*>(&diagFloorPass),
+                reinterpret_cast<void*>(&failDev)
+            };
+
+            const int blocks = (count + colourBlockSize - 1)/colourBlockSize;
+            if (blocks <= 0)
+            {
+                continue;
+            }
+
+            CUresult launch =
+                cuLaunchKernel
+                (
+                    colourBackwardKernel,
+                    blocks, 1, 1,
+                    colourBlockSize, 1, 1,
+                    0,
+                    nullptr,
+                    args,
+                    nullptr
+                );
+
+            if (launch != CUDA_SUCCESS)
+            {
+                disableColour("launchBackward");
+                return false;
+            }
+
+            cudaError_t kernelErr = cudaGetLastError();
+            if (kernelErr != cudaSuccess)
+            {
+                disableColour("backwardKernel");
+                return false;
+            }
+        }
+
+        if (cudaMemcpy(&failHost, d_failFlag, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+        {
+            disableColour("backwardFlag");
+            return false;
+        }
+        if (failHost != 0)
+        {
+            if (failHost == 1)
+            {
+                disableColour("backwardDiagFloor");
+            }
+            else if (failHost == 2)
+            {
+                disableColour("backwardNonFinite");
+            }
+            else
+            {
+                disableColour("backwardInstability");
+            }
+            return false;
+        }
+
+        colourAppliedSuccessfully = true;
+        return true;
+    };
+
     auto applyPreconditionerVec =
         [&](const double* rhs, double* out, const char* stage) -> bool
     {
@@ -627,6 +1740,8 @@ bool Foam::cudaPCG::gpuSolve
                 cusparseDestroyDnVec(vpy);
                 if (spmvStat != CUSPARSE_STATUS_SUCCESS)
                 { message = word("PolySpMVFail"); return false; }
+                if (computeStream && cudaStreamSynchronize(computeStream) != cudaSuccess)
+                { message = word("PolyStreamSyncFail"); return false; }
 
                 // d_preTmp = rhs - t
                 if (cublasDcopy(cublasHandle, rows, rhs, 1, d_preTmp, 1) != CUBLAS_STATUS_SUCCESS)
@@ -754,36 +1869,16 @@ bool Foam::cudaPCG::gpuSolve
             }
             return true;
         }
-        else
+        else if (colourOperational && colourReady)
         {
-            // Diagonal scaling (Jacobi)
-            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            if (applyColourDevice(rhs, out, stage))
             {
-                message = word("DiagCopyFail");
-                return false;
+                return true;
             }
-            if
-            (
-                cublasDdgmm
-                (
-                    cublasHandle,
-                    CUBLAS_SIDE_LEFT,
-                    rows,
-                    1,
-                    out,
-                    rows,
-                    reinterpret_cast<const double*>(d_diagInv),
-                    1,
-                    out,
-                    rows
-                ) != CUBLAS_STATUS_SUCCESS
-            )
-            {
-                message = word("DiagScaleFail");
-                return false;
-            }
-            return true;
+            // applyColourDevice disables the coloured path on failure – fall through to diagonal
         }
+
+        return applyDiagonalDevice(rhs, out);
     };
 
     const double alpha = 1.0;
@@ -957,6 +2052,10 @@ bool Foam::cudaPCG::gpuSolve
     {
         return fail("cusparseSpMV (A*x)");
     }
+    if (!syncStream())
+    {
+        return false;
+    }
 
     if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_b), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
         return fail("cublas copy b->r");
@@ -981,6 +2080,10 @@ bool Foam::cudaPCG::gpuSolve
         cleanup();
         return fail("cublas dot(r,z)");
     }
+    if (!syncStream())
+    {
+        return false;
+    }
     scalar rz = returnReduce(static_cast<scalar>(rzDevice), sumOp<scalar>());
 
     scalar normFactor = this->normFactor(psi, source, wA, pA);
@@ -991,10 +2094,20 @@ bool Foam::cudaPCG::gpuSolve
         cleanup();
         return fail("cublas dasum(r)");
     }
+    if (!syncStream())
+    {
+        return false;
+    }
     scalar sumAbs = returnReduce(static_cast<scalar>(sumAbsDevice), sumOp<scalar>());
 
     solverPerf.initialResidual() = sumAbs/normFactor;
     solverPerf.finalResidual() = solverPerf.initialResidual();
+
+    if (logResidualTrajectory)
+    {
+        residualIterHistory.push_back(0);
+        residualValueHistory.push_back(solverPerf.initialResidual());
+    }
 
     if
     (
@@ -1004,6 +2117,7 @@ bool Foam::cudaPCG::gpuSolve
     {
         cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
         cleanup();
+        writeTelemetry(true, word::null);
         return true;
     }
 
@@ -1018,26 +2132,96 @@ bool Foam::cudaPCG::gpuSolve
      || iter < minIter_
     )
     {
-        if
-        (
-            cusparseDnVecSetValues(vecX, d_p) != CUSPARSE_STATUS_SUCCESS
-         || cusparseDnVecSetValues(vecY, d_Ap) != CUSPARSE_STATUS_SUCCESS
-         || cusparseSpMV
-            (
-                cusparseHandle,
-                CUSPARSE_OPERATION_NON_TRANSPOSE,
-                &alpha,
-                matA,
-                vecX,
-                &zero,
-                vecY,
-                CUDA_R_64F,
-                CUSPARSE_SPMV_ALG_DEFAULT,
-                spmvBuffer
-            ) != CUSPARSE_STATUS_SUCCESS
-        )
+        if (cusparseDnVecSetValues(vecX, d_p) != CUSPARSE_STATUS_SUCCESS)
         {
-            return fail("cusparseSpMV (A*p)");
+            return fail("cusparseSetVec(p)");
+        }
+        if (cusparseDnVecSetValues(vecY, d_Ap) != CUSPARSE_STATUS_SUCCESS)
+        {
+            return fail("cusparseSetVec(Ap)");
+        }
+
+        bool launchedFromGraph = false;
+        if (useCudaGraph)
+        {
+            cudaStream_t activeStream = computeStream ? computeStream : nullptr;
+            if (!spmvGraphReady && iter >= cudaGraphWarmup)
+            {
+                if (cudaStreamBeginCapture(activeStream, cudaStreamCaptureModeGlobal) != cudaSuccess)
+                {
+                    return fail("cudaStreamBeginCapture");
+                }
+                cusparseStatus_t capStatus =
+                    cusparseSpMV
+                    (
+                        cusparseHandle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &alpha,
+                        matA,
+                        vecX,
+                        &zero,
+                        vecY,
+                        CUDA_R_64F,
+                        CUSPARSE_SPMV_ALG_DEFAULT,
+                        spmvBuffer
+                    );
+                if (capStatus != CUSPARSE_STATUS_SUCCESS)
+                {
+                    cudaStreamEndCapture(activeStream, &spmvGraph);
+                    return fail("cusparseSpMV (capture)");
+                }
+                if (cudaStreamEndCapture(activeStream, &spmvGraph) != cudaSuccess)
+                {
+                    return fail("cudaStreamEndCapture");
+                }
+                if (cudaGraphInstantiate(&spmvGraphExec, spmvGraph, nullptr, nullptr, 0) != cudaSuccess)
+                {
+                    return fail("cudaGraphInstantiate");
+                }
+                spmvGraphReady = true;
+                if (cudaGraphLaunch(spmvGraphExec, activeStream) != cudaSuccess)
+                {
+                    return fail("cudaGraphLaunch");
+                }
+                launchedFromGraph = true;
+            }
+            else if (spmvGraphReady)
+            {
+                cudaStream_t launchStream = computeStream ? computeStream : nullptr;
+                if (cudaGraphLaunch(spmvGraphExec, launchStream) != cudaSuccess)
+                {
+                    return fail("cudaGraphLaunch");
+                }
+                launchedFromGraph = true;
+            }
+        }
+
+        if (!launchedFromGraph)
+        {
+            if
+            (
+                cusparseSpMV
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &alpha,
+                    matA,
+                    vecX,
+                    &zero,
+                    vecY,
+                    CUDA_R_64F,
+                    CUSPARSE_SPMV_ALG_DEFAULT,
+                    spmvBuffer
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                return fail("cusparseSpMV (A*p)");
+            }
+        }
+
+        if (!syncStream())
+        {
+            return false;
         }
 
         // Restore vecX to x for completeness
@@ -1049,6 +2233,10 @@ bool Foam::cudaPCG::gpuSolve
         {
             cleanup();
             return fail("cublas dot(p,Ap)");
+        }
+        if (!syncStream())
+        {
+            return false;
         }
         scalar pAp = returnReduce(static_cast<scalar>(pApDevice), sumOp<scalar>());
 
@@ -1071,12 +2259,22 @@ bool Foam::cudaPCG::gpuSolve
             cleanup();
             return fail("cublas dasum(r iter)");
         }
+        if (!syncStream())
+        {
+            return false;
+        }
         sumAbs = returnReduce(static_cast<scalar>(sumAbsDevice), sumOp<scalar>());
 
         solverPerf.finalResidual() = sumAbs/normFactor;
 
         ++iter;
         solverPerf.nIterations() = iter;
+
+        if (logResidualTrajectory && (iter % residualLogEvery == 0))
+        {
+            residualIterHistory.push_back(iter);
+            residualValueHistory.push_back(solverPerf.finalResidual());
+        }
 
         if
         (
@@ -1096,6 +2294,10 @@ bool Foam::cudaPCG::gpuSolve
             cleanup();
             return fail("cublas dot(r,z) iter");
         }
+        if (!syncStream())
+        {
+            return false;
+        }
 
         const scalar rzOld = rz;
         rz = returnReduce(static_cast<scalar>(rzNewDevice), sumOp<scalar>());
@@ -1103,14 +2305,50 @@ bool Foam::cudaPCG::gpuSolve
         const scalar betaStep = rzOld != 0 ? rz/rzOld : 0;
         const double betaDevice = static_cast<double>(betaStep);
 
-        if (cublasDscal(cublasHandle, rows, &betaDevice, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
-            return fail("cublas scal p*=beta");
-        if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&alpha), reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
-            return fail("cublas axpy p+=z");
+        if (usePipelinedCG)
+        {
+            if (cublasDscal(cublasHandle, rows, &betaDevice, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                return fail("cublas scal p*=beta");
+            }
+            const double minusAlphaBetaDevice = -alphaDevice * betaDevice;
+            if (cublasDaxpy(cublasHandle, rows, &minusAlphaBetaDevice, reinterpret_cast<const double*>(d_Ap), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                return fail("cublas axpy p-=alphaBetaAp");
+            }
+            if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&alpha), reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                return fail("cublas axpy p+=z");
+            }
+        }
+        else
+        {
+            if (cublasDscal(cublasHandle, rows, &betaDevice, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                return fail("cublas scal p*=beta");
+            }
+            if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&alpha), reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                return fail("cublas axpy p+=z");
+            }
+        }
     }
 
     cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
     cleanup();
+    if (logResidualTrajectory)
+    {
+        const label lastRecordedIter =
+            residualIterHistory.empty()
+          ? -1
+          : residualIterHistory.back();
+        if (solverPerf.nIterations() > lastRecordedIter)
+        {
+            residualIterHistory.push_back(solverPerf.nIterations());
+            residualValueHistory.push_back(solverPerf.finalResidual());
+        }
+    }
+    writeTelemetry(true, word::null);
     return true;
 }
 

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -3,8 +3,10 @@
 #include "CsrExport.H"
 #include "Switch.H"
 #include "List.H"
+#include "PstreamReduceOps.H"
 
 #include <algorithm>
+#include <limits>
 
 #ifdef FOAM_USE_CUDA
 #include <cuda_runtime.h>
@@ -186,6 +188,9 @@ bool Foam::cudaPCG::gpuSolve
         return true;
     }
 
+    const bool reportStats =
+        controlDict_.lookupOrDefault<Switch>("reportGpuStats", Switch(false));
+
     cudaError_t cudaCode = cudaSetDevice(deviceId);
     if (cudaCode != cudaSuccess)
     {
@@ -198,6 +203,20 @@ bool Foam::cudaPCG::gpuSolve
     {
         message = "CSR row mismatch";
         return false;
+    }
+
+    if (reportStats)
+    {
+        const scalarField& diag = matrix_.diag();
+        scalar minDiag = std::numeric_limits<scalar>::max();
+        scalar maxDiag = -std::numeric_limits<scalar>::max();
+        for (const scalar d : diag)
+        {
+            minDiag = std::min(minDiag, d);
+            maxDiag = std::max(maxDiag, d);
+        }
+        Info<< "cudaPCG: diagonal range [" << minDiag << ", " << maxDiag << "]"
+            << nl;
     }
 
     static_assert(sizeof(scalar) == sizeof(double), "cudaPCG currently requires double precision build");
@@ -269,7 +288,6 @@ bool Foam::cudaPCG::gpuSolve
             cusparseDestroy(cusparseHandle);
             cusparseHandle = nullptr;
         }
-
         if (d_vals) cudaFree(d_vals);
         if (d_x) cudaFree(d_x);
         if (d_b) cudaFree(d_b);
@@ -356,6 +374,39 @@ bool Foam::cudaPCG::gpuSolve
     if (cusparseCreateDnVec(&vecY, rows, d_Ap, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
         return fail("cusparseCreateDnVec(y)");
 
+    auto applyPreconditionerVec =
+        [&](const double* rhs, double* out, const char* stage) -> bool
+    {
+        (void)stage;
+        if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+        {
+            message = word("DiagCopyFail");
+            return false;
+        }
+        if
+        (
+            cublasDdgmm
+            (
+                cublasHandle,
+                CUBLAS_SIDE_LEFT,
+                rows,
+                1,
+                out,
+                rows,
+                reinterpret_cast<const double*>(d_diagInv),
+                1,
+                out,
+                rows
+            ) != CUBLAS_STATUS_SUCCESS
+        )
+        {
+            message = word("DiagScaleFail");
+            return false;
+        }
+
+        return true;
+    };
+
     const double alpha = 1.0;
     const double zero = 0.0;
     const double negOne = -1.0;
@@ -415,30 +466,37 @@ bool Foam::cudaPCG::gpuSolve
     if (cublasDaxpy(cublasHandle, rows, reinterpret_cast<const double*>(&negOne), reinterpret_cast<const double*>(d_Ap), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
         return fail("cublas axpy r -= Ap");
 
-    if (cublasDdgmm(cublasHandle, CUBLAS_SIDE_LEFT, rows, 1, reinterpret_cast<const double*>(d_r), rows, reinterpret_cast<const double*>(d_diagInv), 1, reinterpret_cast<double*>(d_z), rows) != CUBLAS_STATUS_SUCCESS)
-        return fail("cublas dgmm diagInv*r");
+    if (!applyPreconditionerVec(reinterpret_cast<const double*>(d_r), reinterpret_cast<double*>(d_z), "initial"))
+        return fail(message);
 
     if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_z), 1, reinterpret_cast<double*>(d_p), 1) != CUBLAS_STATUS_SUCCESS)
         return fail("cublas copy z->p");
 
-    scalarField rHost(nCells, Zero);
-    scalarField zHost(nCells, Zero);
-    scalarField pHost(nCells, Zero);
     scalarField wA(nCells, Zero);
     scalarField pA(nCells, Zero);
 
-    cudaMemcpy(rHost.begin(), d_r, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
-    cudaMemcpy(zHost.begin(), d_z, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
     cudaMemcpy(wA.begin(), d_Ap, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
-    cudaMemcpy(pHost.begin(), d_p, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    cudaMemcpy(pA.begin(), d_p, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
 
-    scalar rz = gSumProd(rHost, zHost, matrix_.mesh().comm());
+    double rzDevice = 0.0;
+    if (cublasDdot(cublasHandle, rows, reinterpret_cast<const double*>(d_r), 1, reinterpret_cast<const double*>(d_z), 1, &rzDevice) != CUBLAS_STATUS_SUCCESS)
+    {
+        cleanup();
+        return fail("cublas dot(r,z)");
+    }
+    scalar rz = returnReduce(static_cast<scalar>(rzDevice), sumOp<scalar>());
 
     scalar normFactor = this->normFactor(psi, source, wA, pA);
 
-    solverPerf.initialResidual() =
-        gSumMag(rHost, matrix_.mesh().comm())
-       /normFactor;
+    double sumAbsDevice = 0.0;
+    if (cublasDasum(cublasHandle, rows, reinterpret_cast<const double*>(d_r), 1, &sumAbsDevice) != CUBLAS_STATUS_SUCCESS)
+    {
+        cleanup();
+        return fail("cublas dasum(r)");
+    }
+    scalar sumAbs = returnReduce(static_cast<scalar>(sumAbsDevice), sumOp<scalar>());
+
+    solverPerf.initialResidual() = sumAbs/normFactor;
     solverPerf.finalResidual() = solverPerf.initialResidual();
 
     if
@@ -489,10 +547,13 @@ bool Foam::cudaPCG::gpuSolve
         cusparseDnVecSetValues(vecX, d_x);
         cusparseDnVecSetValues(vecY, d_Ap);
 
-        cudaMemcpy(wA.begin(), d_Ap, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
-        cudaMemcpy(pHost.begin(), d_p, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
-
-        scalar pAp = gSumProd(wA, pHost, matrix_.mesh().comm());
+        double pApDevice = 0.0;
+        if (cublasDdot(cublasHandle, rows, reinterpret_cast<const double*>(d_p), 1, reinterpret_cast<const double*>(d_Ap), 1, &pApDevice) != CUBLAS_STATUS_SUCCESS)
+        {
+            cleanup();
+            return fail("cublas dot(p,Ap)");
+        }
+        scalar pAp = returnReduce(static_cast<scalar>(pApDevice), sumOp<scalar>());
 
         if (solverPerf.checkSingularity(mag(pAp)/normFactor))
         {
@@ -508,11 +569,14 @@ bool Foam::cudaPCG::gpuSolve
         if (cublasDaxpy(cublasHandle, rows, &negAlphaDevice, reinterpret_cast<const double*>(d_Ap), 1, reinterpret_cast<double*>(d_r), 1) != CUBLAS_STATUS_SUCCESS)
             return fail("cublas axpy r -= alpha*Ap");
 
-        cudaMemcpy(rHost.begin(), d_r, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+        if (cublasDasum(cublasHandle, rows, reinterpret_cast<const double*>(d_r), 1, &sumAbsDevice) != CUBLAS_STATUS_SUCCESS)
+        {
+            cleanup();
+            return fail("cublas dasum(r iter)");
+        }
+        sumAbs = returnReduce(static_cast<scalar>(sumAbsDevice), sumOp<scalar>());
 
-        solverPerf.finalResidual() =
-            gSumMag(rHost, matrix_.mesh().comm())
-           /normFactor;
+        solverPerf.finalResidual() = sumAbs/normFactor;
 
         ++iter;
         solverPerf.nIterations() = iter;
@@ -526,13 +590,18 @@ bool Foam::cudaPCG::gpuSolve
             break;
         }
 
-        if (cublasDdgmm(cublasHandle, CUBLAS_SIDE_LEFT, rows, 1, reinterpret_cast<const double*>(d_r), rows, reinterpret_cast<const double*>(d_diagInv), 1, reinterpret_cast<double*>(d_z), rows) != CUBLAS_STATUS_SUCCESS)
-            return fail("cublas dgmm diagInv*r (iter)");
+        if (!applyPreconditionerVec(reinterpret_cast<const double*>(d_r), reinterpret_cast<double*>(d_z), "iter"))
+            return fail(message);
 
-        cudaMemcpy(zHost.begin(), d_z, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+        double rzNewDevice = 0.0;
+        if (cublasDdot(cublasHandle, rows, reinterpret_cast<const double*>(d_r), 1, reinterpret_cast<const double*>(d_z), 1, &rzNewDevice) != CUBLAS_STATUS_SUCCESS)
+        {
+            cleanup();
+            return fail("cublas dot(r,z) iter");
+        }
 
         const scalar rzOld = rz;
-        rz = gSumProd(rHost, zHost, matrix_.mesh().comm());
+        rz = returnReduce(static_cast<scalar>(rzNewDevice), sumOp<scalar>());
 
         const scalar betaStep = rzOld != 0 ? rz/rzOld : 0;
         const double betaDevice = static_cast<double>(betaStep);

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -808,6 +808,7 @@ using DeviceScalar = double;
     bool useSGS = false;
     bool useILU = false;
     bool useIC = false;
+    bool useComposite = false;
 
     if
     (
@@ -818,6 +819,8 @@ using DeviceScalar = double;
      || precondLower == "multicolor"
      || precondLower == "colorgs"
      || precondLower == "colourgs"
+     || precondLower.find("colour+ic") != std::string::npos
+     || precondLower.find("color+ic") != std::string::npos
     )
     {
         useColour = true;
@@ -830,10 +833,14 @@ using DeviceScalar = double;
     {
         useILU = true;
     }
-    else if (precondLower == "ic0" || precondLower == "ic" || precondLower == "dic")
+    else if (precondLower == "ic0" || precondLower == "ic" || precondLower == "dic" || precondLower.find("+ic") != std::string::npos)
     {
         // Map DIC to IC0 on GPU for closer parity with CPU
         useIC = true;
+    }
+    if (precondLower == "composite" || precondLower.find("colour+ic") != std::string::npos || precondLower.find("color+ic") != std::string::npos)
+    {
+        useComposite = true;
     }
 
     colourInitiallyRequested = useColour;
@@ -1612,11 +1619,46 @@ using DeviceScalar = double;
     if (useILU || useIC)
     {
         // Allocate separate values array for in-place factorization
+        // Start from host values and apply diagonal regularisation specifically for ILU/IC
+        List<DeviceScalar> iluValsHost(nnz);
+        for (int i = 0; i < nnz; ++i) iluValsHost[i] = values[i];
+
+        const scalar iluDiagAbsFloorCfg = controlDict_.lookupOrDefault<scalar>("iluDiagAbsFloor", diagFloorCfg);
+        const scalar iluDiagRelFloorCfg = controlDict_.lookupOrDefault<scalar>("iluDiagRelFloor", scalar(0));
+        const double iluDiagFloorEff = std::max(static_cast<double>(iluDiagAbsFloorCfg), static_cast<double>(iluDiagRelFloorCfg)*static_cast<double>(maxAbsDiag));
+
+        if (useIC || useILU)
+        {
+            for (int i = 0; i < rows; ++i)
+            {
+                int diagK = -1;
+                for (int k = rowPtr[i]; k < rowPtr[i+1]; ++k)
+                {
+                    if (colInd[k] == i) { diagK = k; break; }
+                }
+                if (diagK >= 0)
+                {
+                    double dv = static_cast<double>(iluValsHost[diagK]);
+                    if (useIC)
+                    {
+                        // IC0 expects positive diagonals
+                        if (dv <= 0.0 || std::abs(dv) < iluDiagFloorEff) dv = iluDiagFloorEff;
+                    }
+                    else
+                    {
+                        // ILU0: avoid near-zero diagonals, preserve sign
+                        if (std::abs(dv) < iluDiagFloorEff) dv = (dv >= 0.0 ? iluDiagFloorEff : -iluDiagFloorEff);
+                    }
+                    iluValsHost[diagK] = static_cast<DeviceScalar>(dv);
+                }
+            }
+        }
+
         if (cudaMalloc(reinterpret_cast<void**>(&d_iluVals), sizeof(DeviceScalar)*nnz) != cudaSuccess)
         {
             iluDisableReason = std::string("allocVals");
         }
-        else if (cudaMemcpy(d_iluVals, d_vals, sizeof(DeviceScalar)*nnz, cudaMemcpyDeviceToDevice) != cudaSuccess)
+        else if (cudaMemcpy(d_iluVals, iluValsHost.begin(), sizeof(DeviceScalar)*nnz, cudaMemcpyHostToDevice) != cudaSuccess)
         {
             iluDisableReason = std::string("copyVals");
         }
@@ -2328,6 +2370,72 @@ using DeviceScalar = double;
                 }
             }
             // No descriptor state to restore when using transient DnVecs
+            return true;
+        }
+        else if (useComposite && icReady && (colourOperational && colourReady))
+        {
+            // Composite: a few coloured sweeps, then IC0
+            const label sweeps = std::max<label>(1, controlDict_.lookupOrDefault<label>("compositeColourSweeps", 2));
+            // First sweep: rhs -> out
+            if (!applyColourDevice(rhs, out, "compColour1"))
+            {
+                // If colour failed, fall back to IC only
+            }
+            else
+            {
+                // Additional sweeps in-place on 'out'
+                for (label s = 1; s < sweeps; ++s)
+                {
+                    if (!applyColourDevice(out, out, "compColourN"))
+                    {
+                        break;
+                    }
+                }
+            }
+            // Apply IC on the (possibly smoothed) vector in 'out'
+            const double oneD = 1.0;
+            cusparseDnVecSetValues(preIn, out);
+            cusparseDnVecSetValues(preOut, d_preTmp);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &oneD,
+                    matLchol,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvLowerChol
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ICLowerFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, d_preTmp);
+            cusparseDnVecSetValues(preOut, out);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_TRANSPOSE,
+                    &oneD,
+                    matLchol,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvUpperTChol
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("ICUpperTFail");
+                return false;
+            }
             return true;
         }
         else if (icReady)

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -780,8 +780,7 @@ using DeviceScalar = double;
     if (reportStats)
     {
         Info<< "cudaPCG: diagonal range [" << minDiag << ", " << maxDiag << "]"
-            << " (regularised [" << minDiagReg << ", " << maxDiagReg << "])"
-            << nl;
+            << " (regularised [" << minDiagReg << ", " << maxDiagReg << "])" << nl;
     }
 
     DeviceScalar *d_vals=nullptr, *d_x=nullptr, *d_b=nullptr;
@@ -853,6 +852,7 @@ using DeviceScalar = double;
     const scalar stallRatioTol =
         controlDict_.lookupOrDefault<scalar>("stallRatioTol", scalar(0.99));
 
+    const Switch equilibrateMatrix = controlDict_.lookupOrDefault<Switch>("equilibrateMatrix", Switch(false));
     const scalar colourOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourOmega", scalar(0.65));
     const scalar colourBackwardOmegaCfg = controlDict_.lookupOrDefault<scalar>("colourBackwardOmega", scalar(0.85));
     const scalar colourDiagFloorCfg = controlDict_.lookupOrDefault<scalar>("colourDiagFloor", scalar(1e-12));
@@ -1265,17 +1265,67 @@ using DeviceScalar = double;
     if (cudaMalloc(reinterpret_cast<void**>(&d_diagInv), sizeof(DeviceScalar)*rows) != cudaSuccess)
         return fail("cudaMalloc(diagInv)");
 
-    // Copy
+    // Optional symmetric diagonal equilibration A' = S*A*S, b' = S*b, x' = S^{-1} x
+    List<DeviceScalar> scaleHost;
+    List<DeviceScalar> invScaleHost;
+    if (equilibrateMatrix)
+    {
+        scaleHost.setSize(rows);
+        invScaleHost.setSize(rows);
+        for (int i = 0; i < rows; ++i)
+        {
+            const double reg = static_cast<double>(precondDiag[i]);
+            const double s = (reg > 0) ? 1.0/std::sqrt(reg) : 1.0;
+            scaleHost[i] = s;
+            invScaleHost[i] = (s != 0.0) ? (1.0/s) : 1.0;
+        }
+        // Scale CSR values on host: a'_{ij} = s_i * a_{ij} * s_j
+        for (int i = 0; i < rows; ++i)
+        {
+            const double si = static_cast<double>(scaleHost[i]);
+            for (int k = rowPtr[i]; k < rowPtr[i+1]; ++k)
+            {
+                const int j = colInd[k];
+                const double sj = static_cast<double>(scaleHost[j]);
+                values[k] = static_cast<DeviceScalar>(static_cast<double>(values[k]) * si * sj);
+            }
+        }
+        // Adjust diagInv for scaled diagonal (approximate: reg' = s_i^2 * reg)
+        for (int i = 0; i < rows; ++i)
+        {
+            const double si = static_cast<double>(scaleHost[i]);
+            const double reg = static_cast<double>(precondDiag[i]) * si * si;
+            diagInv[i] = (reg > VSMALL) ? static_cast<DeviceScalar>(1.0/reg) : static_cast<DeviceScalar>(0);
+        }
+    }
+
+    // Copy values
     if (cudaMemcpy(d_vals, values.begin(), sizeof(DeviceScalar)*nnz, cudaMemcpyHostToDevice) != cudaSuccess)
         return fail("cudaMemcpy(vals)");
     if (cudaMemcpy(d_rowPtr, rowPtr.begin(), sizeof(int)*(rows+1), cudaMemcpyHostToDevice) != cudaSuccess)
         return fail("cudaMemcpy(rowPtr)");
     if (cudaMemcpy(d_colInd, colInd.begin(), sizeof(int)*nnz, cudaMemcpyHostToDevice) != cudaSuccess)
         return fail("cudaMemcpy(colInd)");
-    if (cudaMemcpy(d_x, psi.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
-        return fail("cudaMemcpy(x)");
-    if (cudaMemcpy(d_b, source.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
-        return fail("cudaMemcpy(b)");
+    if (equilibrateMatrix)
+    {
+        List<DeviceScalar> xScaled(rows), bScaled(rows);
+        for (int i = 0; i < rows; ++i)
+        {
+            xScaled[i] = static_cast<DeviceScalar>(static_cast<double>(psi[i]) * static_cast<double>(invScaleHost[i]));
+            bScaled[i] = static_cast<DeviceScalar>(static_cast<double>(source[i]) * static_cast<double>(scaleHost[i]));
+        }
+        if (cudaMemcpy(d_x, xScaled.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+            return fail("cudaMemcpy(xScaled)");
+        if (cudaMemcpy(d_b, bScaled.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+            return fail("cudaMemcpy(bScaled)");
+    }
+    else
+    {
+        if (cudaMemcpy(d_x, psi.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+            return fail("cudaMemcpy(x)");
+        if (cudaMemcpy(d_b, source.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
+            return fail("cudaMemcpy(b)");
+    }
     if (cudaMemcpy(d_diagInv, diagInv.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice) != cudaSuccess)
         return fail("cudaMemcpy(diagInv)");
 
@@ -1391,7 +1441,16 @@ using DeviceScalar = double;
                     DeviceScalar v = values[k];
                     if (j == i)
                     {
-                        v = precondDiag[i];
+                        // Use regularised diagonal; if equilibrated, account for scaling (s_i^2)
+                        if (equilibrateMatrix)
+                        {
+                            const double si = (scaleHost.size() ? static_cast<double>(scaleHost[i]) : 1.0);
+                            v = static_cast<DeviceScalar>(static_cast<double>(precondDiag[i]) * si * si);
+                        }
+                        else
+                        {
+                            v = precondDiag[i];
+                        }
                     }
                     preValsHost[cursor] = v;
                     ++cursor;
@@ -2743,6 +2802,13 @@ using DeviceScalar = double;
     )
     {
         cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+        if (equilibrateMatrix && scaleHost.size())
+        {
+            for (int i = 0; i < rows; ++i)
+            {
+                psi[i] = static_cast<scalar>(static_cast<double>(psi[i]) * static_cast<double>(scaleHost[i]));
+            }
+        }
         cleanup();
         writeTelemetry(true, word::null);
         return true;
@@ -3004,6 +3070,13 @@ using DeviceScalar = double;
     }
 
     cudaMemcpy(psi.begin(), d_x, sizeof(DeviceScalar)*rows, cudaMemcpyDeviceToHost);
+    if (equilibrateMatrix && scaleHost.size())
+    {
+        for (int i = 0; i < rows; ++i)
+        {
+            psi[i] = static_cast<scalar>(static_cast<double>(psi[i]) * static_cast<double>(scaleHost[i]));
+        }
+    }
     cleanup();
     if (logResidualTrajectory)
     {

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.C
@@ -249,6 +249,21 @@ bool Foam::cudaPCG::gpuSolve
     DeviceScalar *d_r=nullptr, *d_p=nullptr, *d_Ap=nullptr;
     DeviceScalar *d_z=nullptr, *d_diagInv=nullptr;
     int *d_rowPtr=nullptr, *d_colInd=nullptr;
+
+    // Optional SGS preconditioner (D+L) solves
+    bool useSGS = false;
+    {
+        const word precName = controlDict_.lookupOrDefault<word>("preconditioner", word("diagonal"));
+        const std::string pl = toLower(precName);
+        useSGS = (pl == "sgs" || pl == "symgaussseidel" || pl == "ic" || pl == "dic");
+    }
+    int *d_preRowPtr=nullptr, *d_preColInd=nullptr;
+    DeviceScalar *d_preVals=nullptr, *d_preTmp=nullptr, *d_preTmp2=nullptr;
+    cusparseSpMatDescr_t matDL = nullptr; // (D+L)
+    cusparseSpSVDescr_t spsvLower = nullptr, spsvUpperT = nullptr;
+    cusparseDnVecDescr_t preIn = nullptr, preOut = nullptr;
+    void* spsvBuf = nullptr;
+    size_t spsvBufSize = 0;
     cusparseHandle_t cusparseHandle = nullptr;
     cublasHandle_t cublasHandle = nullptr;
     cusparseSpMatDescr_t matA = nullptr;
@@ -298,6 +313,17 @@ bool Foam::cudaPCG::gpuSolve
         if (d_diagInv) cudaFree(d_diagInv);
         if (d_rowPtr) cudaFree(d_rowPtr);
         if (d_colInd) cudaFree(d_colInd);
+        if (d_preRowPtr) cudaFree(d_preRowPtr);
+        if (d_preColInd) cudaFree(d_preColInd);
+        if (d_preVals) cudaFree(d_preVals);
+        if (d_preTmp) cudaFree(d_preTmp);
+        if (preIn) cusparseDestroyDnVec(preIn);
+        if (preOut) cusparseDestroyDnVec(preOut);
+        if (matDL) cusparseDestroySpMat(matDL);
+        if (spsvLower) cusparseSpSV_destroyDescr(spsvLower);
+        if (spsvUpperT) cusparseSpSV_destroyDescr(spsvUpperT);
+        if (spsvBuf) cudaFree(spsvBuf);
+        if (d_preTmp2) cudaFree(d_preTmp2);
     };
 
     auto fail = [&](const word& msg)
@@ -374,37 +400,390 @@ bool Foam::cudaPCG::gpuSolve
     if (cusparseCreateDnVec(&vecY, rows, d_Ap, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
         return fail("cusparseCreateDnVec(y)");
 
+    // Build optional SGS preconditioner structures: CSR of (D+L)
+    bool sgsReady = false;
+    label polySweepsCfg = controlDict_.lookupOrDefault<label>("polyJacobiSweeps", 0);
+    scalar jacOmegaCfg = controlDict_.lookupOrDefault<scalar>("jacobiOmega", scalar(0.7));
+    const Switch polyAuto = controlDict_.lookupOrDefault<Switch>("polyJacobiAuto", Switch(true));
+    bool usePolyJacobi = (polySweepsCfg > 0) || polyAuto;
+    label polySweepsEff = polySweepsCfg;
+    double jacOmegaEff = static_cast<double>(jacOmegaCfg);
+    int preRows = 0, preNnz = 0;
+    if (useSGS)
+    {
+        // Count nnz in (D+L)
+        preRows = rows;
+        List<int> preRowPtrHost(rows + 1, 0);
+        for (int i = 0; i < rows; ++i)
+        {
+            int count = 0;
+            for (int k = rowPtr[i]; k < rowPtr[i+1]; ++k)
+            {
+                if (colInd[k] <= i) ++count;
+            }
+            preRowPtrHost[i+1] = preRowPtrHost[i] + count;
+        }
+        preNnz = preRowPtrHost[rows];
+        List<int> preColIndHost(preNnz);
+        List<DeviceScalar> preValsHost(preNnz);
+        // Fill
+        for (int i = 0; i < rows; ++i)
+        {
+            int cursor = preRowPtrHost[i];
+            for (int k = rowPtr[i]; k < rowPtr[i+1]; ++k)
+            {
+                const int j = colInd[k];
+                if (j <= i)
+                {
+                    preColIndHost[cursor] = j;
+                    // Optional tiny diagonal regularisation if needed
+                    DeviceScalar v = values[k];
+                    if (j == i && std::abs(v) < 1e-20) v = (v >= 0 ? 1 : -1)*1e-20;
+                    preValsHost[cursor] = v;
+                    ++cursor;
+                }
+            }
+        }
+
+        // Device allocate/copy
+        if
+        (
+            cudaMalloc(reinterpret_cast<void**>(&d_preRowPtr), sizeof(int)*(preRows+1)) == cudaSuccess
+         && cudaMalloc(reinterpret_cast<void**>(&d_preColInd), sizeof(int)*preNnz) == cudaSuccess
+         && cudaMalloc(reinterpret_cast<void**>(&d_preVals), sizeof(DeviceScalar)*preNnz) == cudaSuccess
+         && cudaMalloc(reinterpret_cast<void**>(&d_preTmp), sizeof(DeviceScalar)*rows) == cudaSuccess
+         && cudaMalloc(reinterpret_cast<void**>(&d_preTmp2), sizeof(DeviceScalar)*rows) == cudaSuccess
+         && cusparseCreateDnVec(&preIn, rows, d_preTmp, CUDA_R_64F) == CUSPARSE_STATUS_SUCCESS
+         && cusparseCreateDnVec(&preOut, rows, d_preTmp, CUDA_R_64F) == CUSPARSE_STATUS_SUCCESS
+        )
+        {
+            if
+            (
+                cudaMemcpy(d_preRowPtr, preRowPtrHost.begin(), sizeof(int)*(preRows+1), cudaMemcpyHostToDevice) == cudaSuccess
+             && cudaMemcpy(d_preColInd, preColIndHost.begin(), sizeof(int)*preNnz, cudaMemcpyHostToDevice) == cudaSuccess
+             && cudaMemcpy(d_preVals, preValsHost.begin(), sizeof(DeviceScalar)*preNnz, cudaMemcpyHostToDevice) == cudaSuccess
+             && cusparseCreateCsr
+                (
+                    &matDL,
+                    static_cast<int64_t>(preRows),
+                    static_cast<int64_t>(preRows),
+                    static_cast<int64_t>(preNnz),
+                    d_preRowPtr,
+                    d_preColInd,
+                    d_preVals,
+                    CUSPARSE_INDEX_32I,
+                    CUSPARSE_INDEX_32I,
+                    CUSPARSE_INDEX_BASE_ZERO,
+                    CUDA_R_64F
+                ) == CUSPARSE_STATUS_SUCCESS
+             && cusparseSpSV_createDescr(&spsvLower) == CUSPARSE_STATUS_SUCCESS
+             && cusparseSpSV_createDescr(&spsvUpperT) == CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                cusparseFillMode_t fill = CUSPARSE_FILL_MODE_LOWER;
+                cusparseDiagType_t diag = CUSPARSE_DIAG_TYPE_NON_UNIT;
+                cusparseSpMatSetAttribute(matDL, CUSPARSE_SPMAT_FILL_MODE, &fill, sizeof(fill));
+                cusparseSpMatSetAttribute(matDL, CUSPARSE_SPMAT_DIAG_TYPE, &diag, sizeof(diag));
+
+                // Buffer size for SpSV (forward and transpose)
+                const double oneD = 1.0;
+                size_t fwd=0, bwd=0;
+                if
+                (
+                    cusparseSpSV_bufferSize
+                    (
+                        cusparseHandle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &oneD,
+                        matDL,
+                        preIn,
+                        preOut,
+                        CUDA_R_64F,
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        spsvLower,
+                        &fwd
+                    ) == CUSPARSE_STATUS_SUCCESS
+                 && cusparseSpSV_bufferSize
+                    (
+                        cusparseHandle,
+                        CUSPARSE_OPERATION_TRANSPOSE,
+                        &oneD,
+                        matDL,
+                        preIn,
+                        preOut,
+                        CUDA_R_64F,
+                        CUSPARSE_SPSV_ALG_DEFAULT,
+                        spsvUpperT,
+                        &bwd
+                    ) == CUSPARSE_STATUS_SUCCESS
+                )
+                {
+                    spsvBufSize = std::max(fwd, bwd);
+                    if (spsvBufSize == 0 || cudaMalloc(&spsvBuf, spsvBufSize) == cudaSuccess)
+                    {
+                        // Analyses
+                        if
+                        (
+                            cusparseSpSV_analysis
+                            (
+                                cusparseHandle,
+                                CUSPARSE_OPERATION_NON_TRANSPOSE,
+                                &oneD,
+                                matDL,
+                                preIn,
+                                preOut,
+                                CUDA_R_64F,
+                                CUSPARSE_SPSV_ALG_DEFAULT,
+                                spsvLower,
+                                spsvBuf
+                            ) == CUSPARSE_STATUS_SUCCESS
+                         && cusparseSpSV_analysis
+                            (
+                                cusparseHandle,
+                                CUSPARSE_OPERATION_TRANSPOSE,
+                                &oneD,
+                                matDL,
+                                preIn,
+                                preOut,
+                                CUDA_R_64F,
+                                CUSPARSE_SPSV_ALG_DEFAULT,
+                                spsvUpperT,
+                                spsvBuf
+                            ) == CUSPARSE_STATUS_SUCCESS
+                        )
+                        {
+                            sgsReady = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     auto applyPreconditionerVec =
         [&](const double* rhs, double* out, const char* stage) -> bool
     {
         (void)stage;
-        if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+        if (usePolyJacobi)
         {
-            message = word("DiagCopyFail");
-            return false;
-        }
-        if
-        (
-            cublasDdgmm
+            // out = omega*D^{-1} rhs
+            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("PolyCopyFail");
+                return false;
+            }
+            if
             (
-                cublasHandle,
-                CUBLAS_SIDE_LEFT,
-                rows,
-                1,
-                out,
-                rows,
-                reinterpret_cast<const double*>(d_diagInv),
-                1,
-                out,
-                rows
-            ) != CUBLAS_STATUS_SUCCESS
-        )
-        {
-            message = word("DiagScaleFail");
-            return false;
-        }
+                cublasDdgmm
+                (
+                    cublasHandle,
+                    CUBLAS_SIDE_LEFT,
+                    rows,
+                    1,
+                    out,
+                    rows,
+                    reinterpret_cast<const double*>(d_diagInv),
+                    1,
+                    out,
+                    rows
+                ) != CUBLAS_STATUS_SUCCESS
+            )
+            {
+                message = word("PolyDiagScaleFail");
+                return false;
+            }
+            const double omega0 = jacOmegaEff;
+            if (cublasDscal(cublasHandle, rows, &omega0, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("PolyScaleOmegaFail");
+                return false;
+            }
 
-        return true;
+            const double oneD = 1.0;
+            const double zeroD = 0.0;
+            for (label s = 1; s < polySweepsEff; ++s)
+            {
+                // t = A*out
+                cusparseDnVecDescr_t vpx = nullptr, vpy = nullptr;
+                if (cusparseCreateDnVec(&vpx, rows, out, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+                { message = word("PolyCreateVecXFail"); return false; }
+                if (cusparseCreateDnVec(&vpy, rows, d_preTmp2, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+                { cusparseDestroyDnVec(vpx); message = word("PolyCreateVecYFail"); return false; }
+                cusparseStatus_t spmvStat =
+                    cusparseSpMV
+                    (
+                        cusparseHandle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &oneD,
+                        matA,
+                        vpx,
+                        &zeroD,
+                        vpy,
+                        CUDA_R_64F,
+                        CUSPARSE_SPMV_ALG_DEFAULT,
+                        spmvBuffer
+                    );
+                cusparseDestroyDnVec(vpx);
+                cusparseDestroyDnVec(vpy);
+                if (spmvStat != CUSPARSE_STATUS_SUCCESS)
+                { message = word("PolySpMVFail"); return false; }
+
+                // d_preTmp = rhs - t
+                if (cublasDcopy(cublasHandle, rows, rhs, 1, d_preTmp, 1) != CUBLAS_STATUS_SUCCESS)
+                {
+                    message = word("PolyTmpCopyFail");
+                    return false;
+                }
+                const double minusOne = -1.0;
+                if (cublasDaxpy(cublasHandle, rows, &minusOne, d_preTmp2, 1, d_preTmp, 1) != CUBLAS_STATUS_SUCCESS)
+                {
+                    message = word("PolyAxpyFail");
+                    return false;
+                }
+
+                // d_preTmp = omega*D^{-1} d_preTmp
+                if
+                (
+                    cublasDdgmm
+                    (
+                        cublasHandle,
+                        CUBLAS_SIDE_LEFT,
+                        rows,
+                        1,
+                        d_preTmp,
+                        rows,
+                        reinterpret_cast<const double*>(d_diagInv),
+                        1,
+                        d_preTmp,
+                        rows
+                    ) != CUBLAS_STATUS_SUCCESS
+                )
+                {
+                    message = word("PolyDiagScale2Fail");
+                    return false;
+                }
+                if (cublasDscal(cublasHandle, rows, &omega0, d_preTmp, 1) != CUBLAS_STATUS_SUCCESS)
+                {
+                    message = word("PolyScale2OmegaFail");
+                    return false;
+                }
+
+                // out += d_preTmp
+                if (cublasDaxpy(cublasHandle, rows, &oneD, d_preTmp, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+                {
+                    message = word("PolyUpdateFail");
+                    return false;
+                }
+            }
+            // No descriptor state to restore when using transient DnVecs
+            return true;
+        }
+        else if (sgsReady)
+        {
+            // out = M^{-1} rhs via SGS: solve (D+L) y = rhs; solve (D+L)^T out = y
+            const double oneD = 1.0;
+            // First, copy rhs into out then into preTmp
+            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("PrecondCopyFail");
+                return false;
+            }
+            cusparseDnVecSetValues(preIn, out);
+            cusparseDnVecSetValues(preOut, d_preTmp);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_NON_TRANSPOSE,
+                    &oneD,
+                    matDL,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvLower
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("SpSV_lower_fail");
+                return false;
+            }
+            // Middle D^{-1} scaling for SSOR: y := D^{-1} y
+            if
+            (
+                cublasDdgmm
+                (
+                    cublasHandle,
+                    CUBLAS_SIDE_LEFT,
+                    rows,
+                    1,
+                    reinterpret_cast<double*>(d_preTmp),
+                    rows,
+                    reinterpret_cast<const double*>(d_diagInv),
+                    1,
+                    reinterpret_cast<double*>(d_preTmp),
+                    rows
+                ) != CUBLAS_STATUS_SUCCESS
+            )
+            {
+                message = word("SSORDiagScaleFail");
+                return false;
+            }
+
+            cusparseDnVecSetValues(preIn, d_preTmp);
+            cusparseDnVecSetValues(preOut, out);
+            if
+            (
+                cusparseSpSV_solve
+                (
+                    cusparseHandle,
+                    CUSPARSE_OPERATION_TRANSPOSE,
+                    &oneD,
+                    matDL,
+                    preIn,
+                    preOut,
+                    CUDA_R_64F,
+                    CUSPARSE_SPSV_ALG_DEFAULT,
+                    spsvUpperT
+                ) != CUSPARSE_STATUS_SUCCESS
+            )
+            {
+                message = word("SpSV_upperT_fail");
+                return false;
+            }
+            return true;
+        }
+        else
+        {
+            // Diagonal scaling (Jacobi)
+            if (cublasDcopy(cublasHandle, rows, rhs, 1, out, 1) != CUBLAS_STATUS_SUCCESS)
+            {
+                message = word("DiagCopyFail");
+                return false;
+            }
+            if
+            (
+                cublasDdgmm
+                (
+                    cublasHandle,
+                    CUBLAS_SIDE_LEFT,
+                    rows,
+                    1,
+                    out,
+                    rows,
+                    reinterpret_cast<const double*>(d_diagInv),
+                    1,
+                    out,
+                    rows
+                ) != CUBLAS_STATUS_SUCCESS
+            )
+            {
+                message = word("DiagScaleFail");
+                return false;
+            }
+            return true;
+        }
     };
 
     const double alpha = 1.0;
@@ -438,6 +817,124 @@ bool Foam::cudaPCG::gpuSolve
         {
             return fail("cudaMalloc(spmvBuffer)");
         }
+    }
+
+    // Optional: auto-tune poly-Jacobi parameters using power iteration on D^{-1}A
+    if (usePolyJacobi && polyAuto)
+    {
+        // allocate temporary vectors
+        DeviceScalar *d_powV = nullptr, *d_powW = nullptr;
+        bool powerReady =
+            cudaMalloc(reinterpret_cast<void**>(&d_powV), sizeof(DeviceScalar)*rows) == cudaSuccess
+         && cudaMalloc(reinterpret_cast<void**>(&d_powW), sizeof(DeviceScalar)*rows) == cudaSuccess;
+
+        if (powerReady)
+        {
+            // initialize v to ones
+            Foam::List<DeviceScalar> onesHost(rows, DeviceScalar(1));
+            cudaMemcpy(d_powV, onesHost.begin(), sizeof(DeviceScalar)*rows, cudaMemcpyHostToDevice);
+
+            const int iters = 8;
+            double vNorm = 0.0;
+            double lambda = 0.0;
+
+            for (int k = 0; k < iters; ++k)
+            {
+                // w = A*v
+                cusparseDnVecDescr_t vDesc = nullptr, wDesc = nullptr;
+                if (cusparseCreateDnVec(&vDesc, rows, d_powV, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+                { powerReady = false; break; }
+                if (cusparseCreateDnVec(&wDesc, rows, d_powW, CUDA_R_64F) != CUSPARSE_STATUS_SUCCESS)
+                { cusparseDestroyDnVec(vDesc); powerReady = false; break; }
+                const double oneD = 1.0, zeroD = 0.0;
+                cusparseStatus_t st =
+                    cusparseSpMV
+                    (
+                        cusparseHandle,
+                        CUSPARSE_OPERATION_NON_TRANSPOSE,
+                        &oneD,
+                        matA,
+                        vDesc,
+                        &zeroD,
+                        wDesc,
+                        CUDA_R_64F,
+                        CUSPARSE_SPMV_ALG_DEFAULT,
+                        spmvBuffer
+                    );
+                cusparseDestroyDnVec(vDesc);
+                cusparseDestroyDnVec(wDesc);
+                if (st != CUSPARSE_STATUS_SUCCESS)
+                { powerReady = false; break; }
+
+                // w = D^{-1} w
+                if
+                (
+                    cublasDdgmm
+                    (
+                        cublasHandle,
+                        CUBLAS_SIDE_LEFT,
+                        rows,
+                        1,
+                        reinterpret_cast<double*>(d_powW),
+                        rows,
+                        reinterpret_cast<const double*>(d_diagInv),
+                        1,
+                        reinterpret_cast<double*>(d_powW),
+                        rows
+                    ) != CUBLAS_STATUS_SUCCESS
+                )
+                { powerReady = false; break; }
+
+                // Rayleigh quotient approx: lambda ≈ (v^T w)/(v^T v)
+                double vTw = 0.0, vTv = 0.0;
+                if (cublasDdot(cublasHandle, rows, reinterpret_cast<const double*>(d_powV), 1, reinterpret_cast<const double*>(d_powW), 1, &vTw) != CUBLAS_STATUS_SUCCESS)
+                { powerReady = false; break; }
+                if (cublasDdot(cublasHandle, rows, reinterpret_cast<const double*>(d_powV), 1, reinterpret_cast<const double*>(d_powV), 1, &vTv) != CUBLAS_STATUS_SUCCESS)
+                { powerReady = false; break; }
+                if (vTv > 0)
+                {
+                    lambda = vTw / vTv;
+                }
+
+                // normalize w -> v
+                if (cublasDnrm2(cublasHandle, rows, reinterpret_cast<const double*>(d_powW), 1, &vNorm) != CUBLAS_STATUS_SUCCESS)
+                { powerReady = false; break; }
+                if (vNorm > 0)
+                {
+                    const double invNorm = 1.0 / vNorm;
+                    if (cublasDcopy(cublasHandle, rows, reinterpret_cast<const double*>(d_powW), 1, reinterpret_cast<double*>(d_powV), 1) != CUBLAS_STATUS_SUCCESS)
+                    { powerReady = false; break; }
+                    if (cublasDscal(cublasHandle, rows, &invNorm, reinterpret_cast<double*>(d_powV), 1) != CUBLAS_STATUS_SUCCESS)
+                    { powerReady = false; break; }
+                }
+            }
+
+            // choose omega and sweeps heuristically
+            double lambdaAbs = std::fabs(lambda);
+            if (lambdaAbs <= 1e-12) lambdaAbs = 1.0; // fallback
+            jacOmegaEff = std::min(0.95, std::max(0.3, 0.8/lambdaAbs));
+            if (polySweepsEff <= 0)
+            {
+                polySweepsEff = (rows > 50000 ? 3 : 2);
+            }
+
+            if (reportStats)
+            {
+                Info<< "cudaPCG: polyJacobi auto omega=" << jacOmegaEff
+                    << ", sweeps=" << polySweepsEff << nl;
+            }
+
+            cudaFree(d_powV);
+            cudaFree(d_powW);
+        }
+        if (!powerReady)
+        {
+            // default heuristic
+            jacOmegaEff = 0.7;
+            if (polySweepsEff <= 0) polySweepsEff = 2;
+        }
+        // ensure poly-Jacobi will run
+        usePolyJacobi = true;
     }
 
     // r = b - A*x

--- a/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.H
+++ b/src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/cudaPCG.H
@@ -1,0 +1,57 @@
+// Minimal header for a runtime-selectable GPU-backed solver (stub)
+
+#ifndef cudaPCG_H
+#define cudaPCG_H
+
+#include "lduMatrix.H"
+
+namespace Foam
+{
+
+class cudaPCG
+:
+    public lduMatrix::solver
+{
+    // not copyable
+    cudaPCG(const cudaPCG&) = delete;
+    void operator=(const cudaPCG&) = delete;
+
+public:
+    TypeName("cudaPCG");
+
+    // Construct from components (matches lduMatrix::solver API)
+    cudaPCG
+    (
+        const word& fieldName,
+        const lduMatrix& matrix,
+        const FieldField<Field, scalar>& interfaceBouCoeffs,
+        const FieldField<Field, scalar>& interfaceIntCoeffs,
+        const lduInterfaceFieldPtrsList& interfaces,
+        const dictionary& solverControls
+    );
+
+    // Solve system Ax=b for psi
+    virtual solverPerformance solve
+    (
+        scalarField& psi,
+        const scalarField& source,
+        const direction cmpt = 0
+    ) const;
+
+#ifdef FOAM_USE_CUDA
+private:
+    bool gpuSolve
+    (
+        scalarField& psi,
+        const scalarField& source,
+        const direction cmpt,
+        solverPerformance& solverPerf,
+        const label deviceId,
+        word& message
+    ) const;
+#endif
+};
+
+} // namespace Foam
+
+#endif

--- a/src/gpu/Make/files
+++ b/src/gpu/Make/files
@@ -1,0 +1,3 @@
+fields/gpuField/gpuField.C
+
+LIB = $(FOAM_USER_LIBBIN)/libgpuFoamPrimitives

--- a/src/gpu/Make/options
+++ b/src/gpu/Make/options
@@ -1,0 +1,5 @@
+EXE_INC = \
+    -I$(LIB_SRC)/OpenFOAM/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude
+
+EXE_LIBS =

--- a/src/gpu/fields/gpuField/gpuField.C
+++ b/src/gpu/fields/gpuField/gpuField.C
@@ -1,0 +1,14 @@
+#include "gpuField.H"
+
+namespace Foam
+{
+namespace gpu
+{
+
+// Currently all inline in header – translation unit present so that the
+// library builds cleanly even before functionality is added.
+
+} // namespace gpu
+} // namespace Foam
+
+// ************************************************************************* //

--- a/src/gpu/fields/gpuField/gpuField.H
+++ b/src/gpu/fields/gpuField/gpuField.H
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     | Website:  https://openfoam.org
+    \\  /    A nd           | Copyright (C) 2025
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Class
+        Foam::gpu::FieldHandle
+
+    Description
+        Lightweight placeholder that marks the intended interface for GPU
+        resident fields.  The implementation is intentionally minimal right
+        now – it simply wraps a host-side field and records a future device
+        pointer slot.  Phase A/B of the acceleration roadmap will replace this
+        with an owning GPU container and asynchronous transfer hooks.
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef Foam_gpu_FieldHandle_H
+#define Foam_gpu_FieldHandle_H
+
+#include "scalarField.H"
+
+namespace Foam
+{
+namespace gpu
+{
+
+class FieldHandle
+{
+    //- Host mirror (temporary stand‑in until GPU storage lands)
+    scalarField* hostPtr_;
+
+    //- Placeholder for a device pointer
+    void* devicePtr_;
+
+public:
+    explicit FieldHandle(scalarField& host)
+    :
+        hostPtr_(&host),
+        devicePtr_(nullptr)
+    {}
+
+    scalarField& host() { return *hostPtr_; }
+    const scalarField& host() const { return *hostPtr_; }
+
+    void* devicePointer() const { return devicePtr_; }
+};
+
+} // namespace gpu
+} // namespace Foam
+
+#endif
+
+// ************************************************************************* //

--- a/src/gpuInfrastructure/DeviceField/DeviceField.C
+++ b/src/gpuInfrastructure/DeviceField/DeviceField.C
@@ -1,0 +1,317 @@
+#include "DeviceField.H"
+#include "error.H"
+#include "volFields.H"
+#include "surfaceFields.H"
+
+namespace Foam
+{
+namespace gpu
+{
+
+defineTypeNameAndDebug(FieldRegistry, 0);
+
+template<class GeoField>
+DeviceField<GeoField>::DeviceField(GeoField& field)
+:
+    field_(field),
+#ifdef FOAM_USE_CUDA
+    devicePtr_(nullptr),
+    count_(0),
+#endif
+    hostDirty_(true),
+    deviceDirty_(false)
+{}
+
+
+template<class GeoField>
+DeviceField<GeoField>::~DeviceField()
+{
+#ifdef FOAM_USE_CUDA
+    if (devicePtr_)
+    {
+        ::cudaFree(devicePtr_);
+        devicePtr_ = nullptr;
+        count_ = 0;
+    }
+#endif
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::allocate(Context& ctx, word& err)
+{
+#ifdef FOAM_USE_CUDA
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, err))
+        {
+            return false;
+        }
+    }
+
+    const label sz = field_.internalField().size();
+    if (sz <= 0)
+    {
+        err.clear();
+        return true;
+    }
+
+    if (devicePtr_ && count_ == sz)
+    {
+        err.clear();
+        return true;
+    }
+
+    if (devicePtr_)
+    {
+        ::cudaFree(devicePtr_);
+        devicePtr_ = nullptr;
+        count_ = 0;
+    }
+
+    cudaError_t status =
+        ::cudaMalloc(reinterpret_cast<void**>(&devicePtr_), sizeof(ValueType)*sz);
+
+    if (status != cudaSuccess)
+    {
+        err = "cudaMalloc(DeviceField)";
+        devicePtr_ = nullptr;
+        count_ = 0;
+        return false;
+    }
+
+    count_ = sz;
+    hostDirty_ = true;
+    deviceDirty_ = false;
+    err.clear();
+    return true;
+#else
+    err = "CUDA support not available";
+    return false;
+#endif
+}
+
+
+template<class GeoField>
+typename DeviceField<GeoField>::ValueType* DeviceField<GeoField>::devicePointer()
+{
+#ifdef FOAM_USE_CUDA
+    return devicePtr_;
+#else
+    return nullptr;
+#endif
+}
+
+
+template<class GeoField>
+const typename DeviceField<GeoField>::ValueType*
+DeviceField<GeoField>::devicePointer() const
+{
+#ifdef FOAM_USE_CUDA
+    return devicePtr_;
+#else
+    return nullptr;
+#endif
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::syncHostToDevice(Context& ctx, word& error)
+{
+#ifdef FOAM_USE_CUDA
+    if (!allocate(ctx, error))
+    {
+        return false;
+    }
+
+    if (!hostDirty_)
+    {
+        error.clear();
+        return true;
+    }
+
+    const label sz = field_.internalField().size();
+    if (sz == 0)
+    {
+        hostDirty_ = false;
+        deviceDirty_ = false;
+        error.clear();
+        return true;
+    }
+
+    const ValueType* hostPtr = field_.primitiveField().begin();
+    cudaError_t status =
+        ::cudaMemcpyAsync
+        (
+            devicePtr_,
+            hostPtr,
+            sizeof(ValueType)*sz,
+            cudaMemcpyHostToDevice,
+            ctx.stream()
+        );
+
+    if (status != cudaSuccess)
+    {
+        error = "cudaMemcpyAsync(host->device)";
+        return false;
+    }
+
+    status = ::cudaStreamSynchronize(ctx.stream());
+    if (status != cudaSuccess)
+    {
+        error = "cudaStreamSynchronize(host->device)";
+        return false;
+    }
+
+    hostDirty_ = false;
+    deviceDirty_ = false;
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::syncDeviceToHost(Context& ctx, word& error)
+{
+#ifdef FOAM_USE_CUDA
+    if (!allocate(ctx, error))
+    {
+        return false;
+    }
+
+    if (!deviceDirty_)
+    {
+        error.clear();
+        return true;
+    }
+
+    const label sz = field_.internalField().size();
+    if (sz == 0)
+    {
+        deviceDirty_ = false;
+        hostDirty_ = false;
+        error.clear();
+        return true;
+    }
+
+    ValueType* hostPtr = field_.primitiveFieldRef().begin();
+    cudaError_t status =
+        ::cudaMemcpyAsync
+        (
+            hostPtr,
+            devicePtr_,
+            sizeof(ValueType)*sz,
+            cudaMemcpyDeviceToHost,
+            ctx.stream()
+        );
+
+    if (status != cudaSuccess)
+    {
+        error = "cudaMemcpyAsync(device->host)";
+        return false;
+    }
+
+    status = ::cudaStreamSynchronize(ctx.stream());
+    if (status != cudaSuccess)
+    {
+        error = "cudaStreamSynchronize(device->host)";
+        return false;
+    }
+
+    deviceDirty_ = false;
+    hostDirty_ = false;
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::allocated() const
+{
+#ifdef FOAM_USE_CUDA
+    return devicePtr_ != nullptr;
+#else
+    return false;
+#endif
+}
+
+
+template<class GeoField>
+label DeviceField<GeoField>::size() const
+{
+#ifdef FOAM_USE_CUDA
+    return count_;
+#else
+    return 0;
+#endif
+}
+
+
+template<class GeoField>
+void DeviceField<GeoField>::markHostDirty()
+{
+    hostDirty_ = true;
+}
+
+
+template<class GeoField>
+void DeviceField<GeoField>::markDeviceDirty()
+{
+    deviceDirty_ = true;
+}
+
+
+FieldRegistry::FieldRegistry(const fvMesh& mesh)
+:
+    MeshObject<fvMesh, GeometricMeshObject, FieldRegistry>(mesh),
+    registry_()
+{}
+
+
+FieldRegistry& FieldRegistry::New(const fvMesh& mesh)
+{
+    return const_cast<FieldRegistry&>
+    (
+        MeshObject<fvMesh, GeometricMeshObject, FieldRegistry>::New(mesh)
+    );
+}
+
+
+template<class GeoField>
+DeviceField<GeoField>& FieldRegistry::getOrCreate(GeoField& field)
+{
+    const void* key = static_cast<const void*>(&field);
+    auto iter = registry_.find(key);
+    if (iter != registry_.end())
+    {
+        return static_cast<DeviceField<GeoField>&>(*iter->second);
+    }
+
+    auto deviceField = std::make_unique<DeviceField<GeoField>>(field);
+    DeviceField<GeoField>& ref = *deviceField;
+    registry_.emplace(key, std::move(deviceField));
+    return ref;
+}
+
+
+// Explicit template instantiations for commonly used field types
+
+template class DeviceField<volScalarField>;
+template class DeviceField<volVectorField>;
+template class DeviceField<surfaceScalarField>;
+template DeviceField<volScalarField>& FieldRegistry::getOrCreate(volScalarField&);
+template DeviceField<volVectorField>& FieldRegistry::getOrCreate(volVectorField&);
+template DeviceField<surfaceScalarField>& FieldRegistry::getOrCreate(surfaceScalarField&);
+
+} // namespace gpu
+} // namespace Foam

--- a/src/gpuInfrastructure/DeviceField/DeviceField.C
+++ b/src/gpuInfrastructure/DeviceField/DeviceField.C
@@ -17,6 +17,9 @@ DeviceField<GeoField>::DeviceField(GeoField& field)
 #ifdef FOAM_USE_CUDA
     devicePtr_(nullptr),
     count_(0),
+    soaPtr_(nullptr),
+    soaCount_(0),
+    soaValid_(false),
 #endif
     hostDirty_(true),
     deviceDirty_(false)
@@ -33,6 +36,7 @@ DeviceField<GeoField>::~DeviceField()
         devicePtr_ = nullptr;
         count_ = 0;
     }
+    freeSoA();
 #endif
 }
 
@@ -68,6 +72,7 @@ bool DeviceField<GeoField>::allocate(Context& ctx, word& err)
         devicePtr_ = nullptr;
         count_ = 0;
     }
+    freeSoA();
 
     cudaError_t status =
         ::cudaMalloc(reinterpret_cast<void**>(&devicePtr_), sizeof(ValueType)*sz);
@@ -83,6 +88,7 @@ bool DeviceField<GeoField>::allocate(Context& ctx, word& err)
     count_ = sz;
     hostDirty_ = true;
     deviceDirty_ = false;
+    soaValid_ = false;
     err.clear();
     return true;
 #else
@@ -147,7 +153,7 @@ bool DeviceField<GeoField>::syncHostToDevice(Context& ctx, word& error)
             hostPtr,
             sizeof(ValueType)*sz,
             cudaMemcpyHostToDevice,
-            ctx.stream()
+            ctx.transferStream()
         );
 
     if (status != cudaSuccess)
@@ -156,7 +162,7 @@ bool DeviceField<GeoField>::syncHostToDevice(Context& ctx, word& error)
         return false;
     }
 
-    status = ::cudaStreamSynchronize(ctx.stream());
+    status = ::cudaStreamSynchronize(ctx.transferStream());
     if (status != cudaSuccess)
     {
         error = "cudaStreamSynchronize(host->device)";
@@ -165,6 +171,7 @@ bool DeviceField<GeoField>::syncHostToDevice(Context& ctx, word& error)
 
     hostDirty_ = false;
     deviceDirty_ = false;
+    soaValid_ = false;
     error.clear();
     return true;
 #else
@@ -200,6 +207,76 @@ bool DeviceField<GeoField>::syncDeviceToHost(Context& ctx, word& error)
     }
 
     ValueType* hostPtr = field_.primitiveFieldRef().begin();
+
+    cudaStream_t transferStream = ctx.transferStream();
+    cudaStream_t computeStream = ctx.computeStream();
+    cudaStream_t auxStream = ctx.auxStream();
+
+    cudaEvent_t computeDone = nullptr;
+    cudaEvent_t auxDone = nullptr;
+
+    auto destroyEvents = [&]()
+    {
+        if (computeDone)
+        {
+            ::cudaEventDestroy(computeDone);
+            computeDone = nullptr;
+        }
+        if (auxDone)
+        {
+            ::cudaEventDestroy(auxDone);
+            auxDone = nullptr;
+        }
+    };
+
+    if (computeStream)
+    {
+        if (::cudaEventCreateWithFlags(&computeDone, cudaEventDisableTiming) != cudaSuccess)
+        {
+            error = "cudaEventCreate(computeDone)";
+            destroyEvents();
+            return false;
+        }
+
+        if (::cudaEventRecord(computeDone, computeStream) != cudaSuccess)
+        {
+            error = "cudaEventRecord(computeDone)";
+            destroyEvents();
+            return false;
+        }
+
+        if (::cudaStreamWaitEvent(transferStream, computeDone, 0) != cudaSuccess)
+        {
+            error = "cudaStreamWaitEvent(computeDone)";
+            destroyEvents();
+            return false;
+        }
+    }
+
+    if (auxStream && auxStream != computeStream)
+    {
+        if (::cudaEventCreateWithFlags(&auxDone, cudaEventDisableTiming) != cudaSuccess)
+        {
+            error = "cudaEventCreate(auxDone)";
+            destroyEvents();
+            return false;
+        }
+
+        if (::cudaEventRecord(auxDone, auxStream) != cudaSuccess)
+        {
+            error = "cudaEventRecord(auxDone)";
+            destroyEvents();
+            return false;
+        }
+
+        if (::cudaStreamWaitEvent(transferStream, auxDone, 0) != cudaSuccess)
+        {
+            error = "cudaStreamWaitEvent(auxDone)";
+            destroyEvents();
+            return false;
+        }
+    }
+
     cudaError_t status =
         ::cudaMemcpyAsync
         (
@@ -207,24 +284,29 @@ bool DeviceField<GeoField>::syncDeviceToHost(Context& ctx, word& error)
             devicePtr_,
             sizeof(ValueType)*sz,
             cudaMemcpyDeviceToHost,
-            ctx.stream()
+            transferStream
         );
 
     if (status != cudaSuccess)
     {
         error = "cudaMemcpyAsync(device->host)";
+        destroyEvents();
         return false;
     }
 
-    status = ::cudaStreamSynchronize(ctx.stream());
+    status = ::cudaStreamSynchronize(transferStream);
     if (status != cudaSuccess)
     {
         error = "cudaStreamSynchronize(device->host)";
+        destroyEvents();
         return false;
     }
 
+    destroyEvents();
+
     deviceDirty_ = false;
     hostDirty_ = false;
+    soaValid_ = false;
     error.clear();
     return true;
 #else
@@ -261,6 +343,9 @@ template<class GeoField>
 void DeviceField<GeoField>::markHostDirty()
 {
     hostDirty_ = true;
+#ifdef FOAM_USE_CUDA
+    soaValid_ = false;
+#endif
 }
 
 
@@ -268,6 +353,183 @@ template<class GeoField>
 void DeviceField<GeoField>::markDeviceDirty()
 {
     deviceDirty_ = true;
+#ifdef FOAM_USE_CUDA
+    soaValid_ = false;
+#endif
+}
+
+
+template<class GeoField>
+void DeviceField<GeoField>::freeSoA()
+{
+#ifdef FOAM_USE_CUDA
+    if (soaPtr_)
+    {
+        ::cudaFree(soaPtr_);
+        soaPtr_ = nullptr;
+    }
+    soaCount_ = 0;
+    soaValid_ = false;
+#endif
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::supportsSoA() const
+{
+    return pTraits<ValueType>::nComponents > 1;
+}
+
+
+template<class GeoField>
+bool DeviceField<GeoField>::ensureSoALayout(Context& ctx, word& error)
+{
+#ifdef FOAM_USE_CUDA
+    if (!supportsSoA())
+    {
+        soaPtr_ = reinterpret_cast<typename pTraits<ValueType>::cmptType*>(devicePtr_);
+        soaCount_ = count_;
+        soaValid_ = true;
+        error.clear();
+        return true;
+    }
+
+    if (!syncHostToDevice(ctx, error))
+    {
+        return false;
+    }
+
+    const label sz = size();
+    if (!sz)
+    {
+        soaValid_ = true;
+        error.clear();
+        return true;
+    }
+
+    const label components = pTraits<ValueType>::nComponents;
+    const std::size_t componentSize = sizeof(typename pTraits<ValueType>::cmptType);
+    const std::size_t dstPitch = componentSize;
+    const std::size_t srcPitch = componentSize*components;
+
+    if (!soaPtr_ || soaCount_ != sz)
+    {
+        if (soaPtr_)
+        {
+            ::cudaFree(soaPtr_);
+        }
+
+        cudaError_t status = ::cudaMalloc
+        (
+            reinterpret_cast<void**>(&soaPtr_),
+            componentSize*components*sz
+        );
+
+        if (status != cudaSuccess)
+        {
+            soaPtr_ = nullptr;
+            soaCount_ = 0;
+            error = "cudaMalloc(DeviceField::SoA)";
+            return false;
+        }
+
+        soaCount_ = sz;
+        soaValid_ = false;
+    }
+
+    if (soaValid_)
+    {
+        error.clear();
+        return true;
+    }
+
+    for (label cmpt = 0; cmpt < components; ++cmpt)
+    {
+        char* dst = reinterpret_cast<char*>(soaPtr_)
+          + cmpt*componentSize*soaCount_;
+
+        const char* src = reinterpret_cast<const char*>(devicePtr_)
+          + cmpt*componentSize;
+
+        cudaError_t status = ::cudaMemcpy2DAsync
+        (
+            dst,
+            dstPitch,
+            src,
+            srcPitch,
+            componentSize,
+            static_cast<size_t>(soaCount_),
+            cudaMemcpyDeviceToDevice,
+            ctx.auxStream()
+        );
+
+        if (status != cudaSuccess)
+        {
+            error = "cudaMemcpy2DAsync(AoS->SoA)";
+            return false;
+        }
+    }
+
+    cudaStream_t auxStream = ctx.auxStream();
+    if (auxStream)
+    {
+        cudaEvent_t copyDone = nullptr;
+        if (::cudaEventCreateWithFlags(&copyDone, cudaEventDisableTiming) != cudaSuccess)
+        {
+            error = "cudaEventCreate(soaCopy)";
+            return false;
+        }
+
+        if (::cudaEventRecord(copyDone, auxStream) != cudaSuccess)
+        {
+            ::cudaEventDestroy(copyDone);
+            error = "cudaEventRecord(soaCopy)";
+            return false;
+        }
+
+        cudaStream_t computeStream = ctx.computeStream();
+        if (::cudaStreamWaitEvent(computeStream, copyDone, 0) != cudaSuccess)
+        {
+            ::cudaEventDestroy(copyDone);
+            error = "cudaStreamWaitEvent(soaCopy)";
+            return false;
+        }
+
+        ::cudaEventDestroy(copyDone);
+    }
+
+    soaValid_ = true;
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)error;
+    return false;
+#endif
+}
+
+
+template<class GeoField>
+typename pTraits<typename DeviceField<GeoField>::ValueType>::cmptType*
+DeviceField<GeoField>::soaPointer()
+{
+#ifdef FOAM_USE_CUDA
+    return soaPtr_;
+#else
+    return nullptr;
+#endif
+}
+
+
+template<class GeoField>
+const typename pTraits<typename DeviceField<GeoField>::ValueType>::cmptType*
+DeviceField<GeoField>::soaPointer() const
+{
+#ifdef FOAM_USE_CUDA
+    return soaPtr_;
+#else
+    return nullptr;
+#endif
 }
 
 

--- a/src/gpuInfrastructure/DeviceField/DeviceField.H
+++ b/src/gpuInfrastructure/DeviceField/DeviceField.H
@@ -5,6 +5,7 @@
 #include "fvMesh.H"
 #include "MeshObject.H"
 #include "word.H"
+#include "pTraits.H"
 
 #include <memory>
 #include <unordered_map>
@@ -41,12 +42,16 @@ class DeviceField
 #ifdef FOAM_USE_CUDA
     ValueType* devicePtr_;
     label count_;
+    typename pTraits<ValueType>::cmptType* soaPtr_;
+    label soaCount_;
+    bool soaValid_;
 #endif
 
     bool hostDirty_;
     bool deviceDirty_;
 
     bool allocate(Context& ctx, word& err);
+    void freeSoA();
 
 public:
 
@@ -66,6 +71,16 @@ public:
 
     void markHostDirty();
     void markDeviceDirty();
+
+    //- Return true when a SoA layout can be produced for this field.
+    bool supportsSoA() const;
+
+    //- Ensure the SoA layout is up to date on the device. Returns true on success.
+    bool ensureSoALayout(Context& ctx, word& error);
+
+    //- Access the SoA device pointer (nullptr if unavailable).
+    typename pTraits<ValueType>::cmptType* soaPointer();
+    const typename pTraits<ValueType>::cmptType* soaPointer() const;
 };
 
 

--- a/src/gpuInfrastructure/DeviceField/DeviceField.H
+++ b/src/gpuInfrastructure/DeviceField/DeviceField.H
@@ -1,0 +1,93 @@
+#ifndef Foam_gpu_DeviceField_H
+#define Foam_gpu_DeviceField_H
+
+#include "GpuContext.H"
+#include "fvMesh.H"
+#include "MeshObject.H"
+#include "word.H"
+
+#include <memory>
+#include <unordered_map>
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda_runtime.h>
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+class DeviceFieldBase
+{
+public:
+    virtual ~DeviceFieldBase() = default;
+    virtual bool syncHostToDevice(Context& ctx, word& error) = 0;
+    virtual bool syncDeviceToHost(Context& ctx, word& error) = 0;
+    virtual bool allocated() const = 0;
+    virtual label size() const = 0;
+};
+
+
+template<class GeoField>
+class DeviceField
+:
+    public DeviceFieldBase
+{
+    typedef typename GeoField::value_type ValueType;
+
+    GeoField& field_;
+
+#ifdef FOAM_USE_CUDA
+    ValueType* devicePtr_;
+    label count_;
+#endif
+
+    bool hostDirty_;
+    bool deviceDirty_;
+
+    bool allocate(Context& ctx, word& err);
+
+public:
+
+    explicit DeviceField(GeoField& field);
+    ~DeviceField() override;
+
+    DeviceField(const DeviceField&) = delete;
+    DeviceField& operator=(const DeviceField&) = delete;
+
+    ValueType* devicePointer();
+    const ValueType* devicePointer() const;
+
+    bool syncHostToDevice(Context& ctx, word& error) override;
+    bool syncDeviceToHost(Context& ctx, word& error) override;
+    bool allocated() const override;
+    label size() const override;
+
+    void markHostDirty();
+    void markDeviceDirty();
+};
+
+
+class FieldRegistry
+:
+    public MeshObject<fvMesh, GeometricMeshObject, FieldRegistry>
+{
+    std::unordered_map<const void*, std::unique_ptr<DeviceFieldBase>> registry_;
+
+public:
+
+    TypeName("gpuFieldRegistry");
+
+    explicit FieldRegistry(const fvMesh& mesh);
+
+    static FieldRegistry& New(const fvMesh& mesh);
+
+    template<class GeoField>
+    DeviceField<GeoField>& getOrCreate(GeoField& field);
+};
+
+} // namespace gpu
+} // namespace Foam
+
+#endif

--- a/src/gpuInfrastructure/FieldOps/FieldOps.C
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.C
@@ -1,6 +1,9 @@
 #include "FieldOps.H"
 #include "error.H"
+#include "KernelCache.H"
+#include "OSspecific.H"
 
+#include <cctype>
 #include <string>
 #include <sstream>
 
@@ -19,43 +22,9 @@ namespace gpu
 namespace
 {
 
-std::string nvrtcErrorString(const nvrtcResult code)
+const std::string& surfaceSubtractSource()
 {
-    return std::string(nvrtcGetErrorString(code))
-        + " (" + Foam::name(static_cast<int>(code)) + ')';
-}
-
-
-std::string cudaDriverErrorString(const CUresult code)
-{
-    const char* msg = nullptr;
-    cuGetErrorString(code, &msg);
-    if (msg)
-    {
-        return std::string(msg)
-            + " (" + Foam::name(static_cast<int>(code)) + ')';
-    }
-    return "cuda driver error (" + Foam::name(static_cast<int>(code)) + ')';
-}
-
-
-bool compileSurfaceSubtractKernel(CUmodule& module, CUfunction& function, word& error)
-{
-    static bool initialised = false;
-    static CUmodule cachedModule = nullptr;
-    static CUfunction cachedFunction = nullptr;
-
-    if (initialised)
-    {
-        module = cachedModule;
-        function = cachedFunction;
-        error.clear();
-        return cachedModule != nullptr && cachedFunction != nullptr;
-    }
-
-    initialised = true;
-
-    const char* source = R"(
+    static const std::string src = R"(
 extern "C" __global__
 void surfaceSubtract(double* dst, const double* a, const double* b, int n)
 {
@@ -66,81 +35,112 @@ void surfaceSubtract(double* dst, const double* a, const double* b, int n)
     }
 }
 )";
+    return src;
+}
 
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source,
-        "surfaceSubtract.cu",
-        0,
-        nullptr,
-        nullptr
-    );
 
-    if (nvStatus != NVRTC_SUCCESS)
+const std::string& velocityCorrectorAoSSource()
+{
+    static const std::string src = R"(
+extern "C" __global__
+void velocityCorrector(double* u, const double* h, const double* grad, const double* r, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
     {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
+        double rVal = r[idx];
+        int base = idx * 3;
+        u[base]     = h[base]     - rVal * grad[base];
+        u[base + 1] = h[base + 1] - rVal * grad[base + 1];
+        u[base + 2] = h[base + 2] - rVal * grad[base + 2];
+    }
+}
+)";
+    return src;
+}
+
+
+const std::string& velocityCorrectorSoASource()
+{
+    static const std::string src = R"(
+extern "C" __global__
+void velocityCorrectorSoA
+(
+    double* u,
+    const double* hx,
+    const double* hy,
+    const double* hz,
+    const double* gx,
+    const double* gy,
+    const double* gz,
+    const double* r,
+    int n
+)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        double rVal = r[idx];
+        int base = idx * 3;
+        u[base]     = hx[idx] - rVal * gx[idx];
+        u[base + 1] = hy[idx] - rVal * gy[idx];
+        u[base + 2] = hz[idx] - rVal * gz[idx];
+    }
+}
+)";
+    return src;
+}
+
+
+const std::string& computeNutKernelSource()
+{
+    static const std::string src = R"(
+extern "C" __global__
+void computeNut(double* nut, const double* k, const double* epsilon,
+                const double Cmu, const double kMin, const double epsilonMin,
+                const int n)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n)
+    {
+        return;
     }
 
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
+    double kval = k[idx];
+    if (kval < kMin)
     {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
+        kval = kMin;
+    }
+
+    double eps = epsilon[idx];
+    if (eps < epsilonMin)
+    {
+        eps = epsilonMin;
+    }
+
+    const double value = Cmu * kval * kval / eps;
+    nut[idx] = value;
+}
+)";
+    return src;
+}
+
+
+bool preferVectorSoA()
+{
+    static const bool prefer = []
+    {
+        word value = getEnv("FOAM_GPU_PREFER_SOA");
+        for (char& c : value)
         {
-            nvrtcGetProgramLog(prog, &log[0]);
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
         }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "surfaceSubtract");
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    module = cachedModule;
-    function = cachedFunction;
-    error.clear();
-    return true;
+        return value == "1"
+            || value == "true"
+            || value == "on"
+            || value == "yes";
+    }();
+    return prefer;
 }
 
 } // namespace
@@ -174,13 +174,6 @@ bool subtractSurfaceScalarFields
         }
     }
 
-    CUmodule module = nullptr;
-    CUfunction function = nullptr;
-    if (!compileSurfaceSubtractKernel(module, function, error))
-    {
-        return false;
-    }
-
     const label n = dst.size();
     if (n == 0)
     {
@@ -210,55 +203,55 @@ bool subtractSurfaceScalarFields
 
     void* args[] = { &dstPtr, &aPtr, &bPtr, &nCells };
 
-    cudaEvent_t startEvent = nullptr;
-    cudaEvent_t stopEvent = nullptr;
-
-    if (stats)
+    CompiledKernel kernel;
+    static const word kernelKey("surfaceSubtract");
+    if
+    (
+        !KernelCache::instance().getOrCompile
+        (
+            ctx,
+            kernelKey,
+            surfaceSubtractSource(),
+            {},
+            "surfaceSubtract",
+            kernel,
+            error
+        )
+    )
     {
-        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-        cudaEventRecord(startEvent, ctx.stream());
+        return false;
     }
 
-    CUresult status = cuLaunchKernel
-    (
-        function,
-        gridSize, 1, 1,
-        blockSize, 1, 1,
-        0,
-        reinterpret_cast<CUstream>(ctx.stream()),
-        args,
-        nullptr
-    );
+    scalar elapsedMs = 0;
 
-    if (status != CUDA_SUCCESS)
+    if
+    (
+        !GraphLaunchCache::instance().launch
+        (
+            ctx,
+            kernelKey,
+            kernel,
+            StreamCategory::aux,
+            dim3(gridSize, 1, 1),
+            dim3(blockSize, 1, 1),
+            args,
+            sizeof(args)/sizeof(args[0]),
+            0,
+            error,
+            stats != nullptr,
+            elapsedMs
+        )
+    )
     {
-        error = "cuLaunchKernel failed: " + cudaDriverErrorString(status);
         return false;
     }
 
     if (stats)
     {
-        cudaEventRecord(stopEvent, ctx.stream());
-        cudaEventSynchronize(stopEvent);
-
-        float ms = 0.0f;
-        cudaEventElapsedTime(&ms, startEvent, stopEvent);
-
-        stats->gpuMilliseconds = static_cast<scalar>(ms);
-        cudaEventDestroy(startEvent);
-        cudaEventDestroy(stopEvent);
-    }
-    else
-    {
-        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
-        if (status != CUDA_SUCCESS)
-        {
-            error = "cuStreamSynchronize failed: " + cudaDriverErrorString(status);
-            return false;
-        }
+        stats->gpuMilliseconds = elapsedMs;
     }
 
+    dst.markDeviceDirty();
     error.clear();
     return true;
 #else
@@ -270,116 +263,6 @@ bool subtractSurfaceScalarFields
     return false;
 #endif
 }
-
-#ifdef FOAM_USE_CUDA
-bool compileVelocityCorrectorKernel(CUmodule& module, CUfunction& function, word& error)
-{
-    static bool initialised = false;
-    static CUmodule cachedModule = nullptr;
-    static CUfunction cachedFunction = nullptr;
-
-    if (initialised)
-    {
-        module = cachedModule;
-        function = cachedFunction;
-        error.clear();
-        return cachedModule != nullptr && cachedFunction != nullptr;
-    }
-
-    initialised = true;
-
-    const char* source = R"(
-extern "C" __global__
-void velocityCorrector(double* u, const double* h, const double* grad, const double* r, int n)
-{
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n)
-    {
-        double rVal = r[idx];
-        int base = idx * 3;
-        u[base]     = h[base]     - rVal * grad[base];
-        u[base + 1] = h[base + 1] - rVal * grad[base + 1];
-        u[base + 2] = h[base + 2] - rVal * grad[base + 2];
-    }
-}
-)";
-
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source,
-        "velocityCorrector.cu",
-        0,
-        nullptr,
-        nullptr
-    );
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
-    }
-
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
-        {
-            nvrtcGetProgramLog(prog, &log[0]);
-        }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "velocityCorrector");
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    module = cachedModule;
-    function = cachedFunction;
-    error.clear();
-    return true;
-}
-#endif
 
 
 bool velocityCorrector
@@ -408,13 +291,6 @@ bool velocityCorrector
         {
             return false;
         }
-    }
-
-    CUmodule module = nullptr;
-    CUfunction function = nullptr;
-    if (!compileVelocityCorrectorKernel(module, function, error))
-    {
-        return false;
     }
 
     const label n = U.size();
@@ -448,57 +324,162 @@ bool velocityCorrector
     const unsigned int blockSize = 256;
     const unsigned int gridSize = (nCells + blockSize - 1)/blockSize;
 
-    void* args[] = { &uPtr, &hPtr, &gradPtr, &rPtr, &nCells };
+    scalar elapsedMs = 0;
 
-    cudaEvent_t startEvent = nullptr;
-    cudaEvent_t stopEvent = nullptr;
+    const bool useSoA =
+        preferVectorSoA()
+     && HbyA.supportsSoA()
+     && gradP.supportsSoA();
 
-    if (stats)
+    CompiledKernel kernel;
+
+    if (useSoA)
     {
-        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-        cudaEventRecord(startEvent, ctx.stream());
-    }
+        DeviceField<volVectorField>& hMutable =
+            const_cast<DeviceField<volVectorField>&>(HbyA);
+        DeviceField<volVectorField>& gradMutable =
+            const_cast<DeviceField<volVectorField>&>(gradP);
 
-    CUresult status = cuLaunchKernel
-    (
-        function,
-        gridSize, 1, 1,
-        blockSize, 1, 1,
-        0,
-        reinterpret_cast<CUstream>(ctx.stream()),
-        args,
-        nullptr
-    );
+        if
+        (
+            !hMutable.ensureSoALayout(ctx, error)
+         || !gradMutable.ensureSoALayout(ctx, error)
+        )
+        {
+            return false;
+        }
 
-    if (status != CUDA_SUCCESS)
-    {
-        error = "cuLaunchKernel failed: " + cudaDriverErrorString(status);
-        return false;
-    }
+        double* hSoA =
+            const_cast<double*>
+            (
+                reinterpret_cast<const double*>(hMutable.soaPointer())
+            );
+        double* gradSoA =
+            const_cast<double*>
+            (
+                reinterpret_cast<const double*>(gradMutable.soaPointer())
+            );
 
-    if (stats)
-    {
-        cudaEventRecord(stopEvent, ctx.stream());
-        cudaEventSynchronize(stopEvent);
+        if (!hSoA || !gradSoA)
+        {
+            error = "velocityCorrector: SoA pointers are null";
+            return false;
+        }
 
-        float ms = 0.0f;
-        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+        double* hx = hSoA;
+        double* hy = hSoA + n;
+        double* hz = hSoA + n*2;
 
-        stats->gpuMilliseconds = static_cast<scalar>(ms);
-        cudaEventDestroy(startEvent);
-        cudaEventDestroy(stopEvent);
+        double* gx = gradSoA;
+        double* gy = gradSoA + n;
+        double* gz = gradSoA + n*2;
+
+        void* args[] =
+        {
+            &uPtr,
+            &hx,
+            &hy,
+            &hz,
+            &gx,
+            &gy,
+            &gz,
+            &rPtr,
+            &nCells
+        };
+
+        static const word kernelKey("velocityCorrectorSoA");
+
+        if
+        (
+            !KernelCache::instance().getOrCompile
+            (
+                ctx,
+                kernelKey,
+                velocityCorrectorSoASource(),
+                {},
+                "velocityCorrectorSoA",
+                kernel,
+                error
+            )
+        )
+        {
+            return false;
+        }
+
+        if
+        (
+            !GraphLaunchCache::instance().launch
+        (
+            ctx,
+            kernelKey,
+            kernel,
+            StreamCategory::compute,
+            dim3(gridSize, 1, 1),
+            dim3(blockSize, 1, 1),
+            args,
+            sizeof(args)/sizeof(args[0]),
+            0,
+                error,
+                stats != nullptr,
+                elapsedMs
+            )
+        )
+        {
+            return false;
+        }
     }
     else
     {
-        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
-        if (status != CUDA_SUCCESS)
+        void* args[] = { &uPtr, &hPtr, &gradPtr, &rPtr, &nCells };
+
+        static const word kernelKey("velocityCorrectorAoS");
+
+        if
+        (
+            !KernelCache::instance().getOrCompile
+            (
+                ctx,
+                kernelKey,
+                velocityCorrectorAoSSource(),
+                {},
+                "velocityCorrector",
+                kernel,
+                error
+            )
+        )
         {
-            error = "cuStreamSynchronize failed: " + cudaDriverErrorString(status);
+            return false;
+        }
+
+        if
+        (
+            !GraphLaunchCache::instance().launch
+        (
+            ctx,
+            kernelKey,
+            kernel,
+            StreamCategory::compute,
+            dim3(gridSize, 1, 1),
+            dim3(blockSize, 1, 1),
+            args,
+            sizeof(args)/sizeof(args[0]),
+            0,
+                error,
+                stats != nullptr,
+                elapsedMs
+            )
+        )
+        {
             return false;
         }
     }
 
+    if (stats)
+    {
+        stats->gpuMilliseconds = elapsedMs;
+    }
+
+    U.markDeviceDirty();
     error.clear();
     return true;
 #else
@@ -512,136 +493,6 @@ bool velocityCorrector
     return false;
 #endif
 }
-
-#ifdef FOAM_USE_CUDA
-namespace
-{
-
-bool compileNutKernel(CUmodule& module, CUfunction& function, word& error)
-{
-    static bool initialised = false;
-    static CUmodule cachedModule = nullptr;
-    static CUfunction cachedFunction = nullptr;
-
-    if (initialised)
-    {
-        module = cachedModule;
-        function = cachedFunction;
-        error.clear();
-        return cachedModule != nullptr && cachedFunction != nullptr;
-    }
-
-    initialised = true;
-
-    const char* source = R"(
-extern "C" __global__
-void computeNut(double* nut, const double* k, const double* epsilon,
-                const double Cmu, const double kMin, const double epsilonMin,
-                const int n)
-{
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= n)
-    {
-        return;
-    }
-
-    double kval = k[idx];
-    if (kval < kMin)
-    {
-        kval = kMin;
-    }
-
-    double eps = epsilon[idx];
-    if (eps < epsilonMin)
-    {
-        eps = epsilonMin;
-    }
-
-    const double value = Cmu * kval * kval / eps;
-    nut[idx] = value;
-}
-)";
-
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source,
-        "computeNut.cu",
-        0,
-        nullptr,
-        nullptr
-    );
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
-    }
-
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
-        {
-            nvrtcGetProgramLog(prog, &log[0]);
-        }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "computeNut");
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cuModuleUnload(cachedModule);
-        cachedModule = nullptr;
-        cachedFunction = nullptr;
-        return false;
-    }
-
-    module = cachedModule;
-    function = cachedFunction;
-    error.clear();
-    return true;
-}
-
-} // namespace
-#endif
 
 
 bool computeNutFromKEpsilon
@@ -699,13 +550,6 @@ bool computeNutFromKEpsilon
         return false;
     }
 
-    CUmodule module = nullptr;
-    CUfunction function = nullptr;
-    if (!compileNutKernel(module, function, error))
-    {
-        return false;
-    }
-
     double* nutPtr = reinterpret_cast<double*>(nutMutable.devicePointer());
     double* kPtr = reinterpret_cast<double*>(kMutable.devicePointer());
     double* epsPtr = reinterpret_cast<double*>(epsilonMutable.devicePointer());
@@ -732,54 +576,53 @@ bool computeNutFromKEpsilon
         &cells
     };
 
-    cudaEvent_t startEvent = nullptr;
-    cudaEvent_t stopEvent = nullptr;
+    static const word kernelKey("computeNut");
+    CompiledKernel kernel;
 
-    if (stats)
+    if
+    (
+        !KernelCache::instance().getOrCompile
+        (
+            ctx,
+            kernelKey,
+            computeNutKernelSource(),
+            {},
+            "computeNut",
+            kernel,
+            error
+        )
+    )
     {
-        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-        cudaEventRecord(startEvent, ctx.stream());
+        return false;
     }
 
-    CUresult status = cuLaunchKernel
-    (
-        function,
-        (cells + 255)/256, 1, 1,
-        256, 1, 1,
-        0,
-        reinterpret_cast<CUstream>(ctx.stream()),
-        args,
-        nullptr
-    );
+    scalar elapsedMs = 0;
 
-    if (status != CUDA_SUCCESS)
+    if
+    (
+        !GraphLaunchCache::instance().launch
+        (
+            ctx,
+            kernelKey,
+            kernel,
+            StreamCategory::compute,
+            dim3((cells + 255)/256, 1, 1),
+            dim3(256, 1, 1),
+            args,
+            sizeof(args)/sizeof(args[0]),
+            0,
+            error,
+            stats != nullptr,
+            elapsedMs
+        )
+    )
     {
-        error = "cuLaunchKernel(computeNut) failed: "
-          + cudaDriverErrorString(status);
         return false;
     }
 
     if (stats)
     {
-        cudaEventRecord(stopEvent, ctx.stream());
-        cudaEventSynchronize(stopEvent);
-
-        float ms = 0.0f;
-        cudaEventElapsedTime(&ms, startEvent, stopEvent);
-        stats->gpuMilliseconds = static_cast<scalar>(ms);
-        cudaEventDestroy(startEvent);
-        cudaEventDestroy(stopEvent);
-    }
-    else
-    {
-        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
-        if (status != CUDA_SUCCESS)
-        {
-            error = "cuStreamSynchronize failed: "
-              + cudaDriverErrorString(status);
-            return false;
-        }
+        stats->gpuMilliseconds = elapsedMs;
     }
 
     nutMutable.markDeviceDirty();

--- a/src/gpuInfrastructure/FieldOps/FieldOps.C
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.C
@@ -2,6 +2,7 @@
 #include "error.H"
 
 #include <string>
+#include <sstream>
 
 #ifdef FOAM_USE_CUDA
     #include <cuda.h>
@@ -83,8 +84,15 @@ void surfaceSubtract(double* dst, const double* a, const double* b, int n)
         return false;
     }
 
-    const char* options[] = { "--std=c++14" };
-    nvStatus = nvrtcCompileProgram(prog, 1, options);
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
 
     if (nvStatus != NVRTC_SUCCESS)
     {
@@ -313,8 +321,15 @@ void velocityCorrector(double* u, const double* h, const double* grad, const dou
         return false;
     }
 
-    const char* options[] = { "--std=c++14" };
-    nvStatus = nvrtcCompileProgram(prog, 1, options);
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
 
     if (nvStatus != NVRTC_SUCCESS)
     {

--- a/src/gpuInfrastructure/FieldOps/FieldOps.C
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.C
@@ -513,5 +513,296 @@ bool velocityCorrector
 #endif
 }
 
+#ifdef FOAM_USE_CUDA
+namespace
+{
+
+bool compileNutKernel(CUmodule& module, CUfunction& function, word& error)
+{
+    static bool initialised = false;
+    static CUmodule cachedModule = nullptr;
+    static CUfunction cachedFunction = nullptr;
+
+    if (initialised)
+    {
+        module = cachedModule;
+        function = cachedFunction;
+        error.clear();
+        return cachedModule != nullptr && cachedFunction != nullptr;
+    }
+
+    initialised = true;
+
+    const char* source = R"(
+extern "C" __global__
+void computeNut(double* nut, const double* k, const double* epsilon,
+                const double Cmu, const double kMin, const double epsilonMin,
+                const int n)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n)
+    {
+        return;
+    }
+
+    double kval = k[idx];
+    if (kval < kMin)
+    {
+        kval = kMin;
+    }
+
+    double eps = epsilon[idx];
+    if (eps < epsilonMin)
+    {
+        eps = epsilonMin;
+    }
+
+    const double value = Cmu * kval * kval / eps;
+    nut[idx] = value;
+}
+)";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source,
+        "computeNut.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "computeNut");
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cuModuleUnload(cachedModule);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    module = cachedModule;
+    function = cachedFunction;
+    error.clear();
+    return true;
+}
+
+} // namespace
+#endif
+
+
+bool computeNutFromKEpsilon
+(
+    Context& ctx,
+    DeviceField<volScalarField>& nut,
+    const DeviceField<volScalarField>& k,
+    const DeviceField<volScalarField>& epsilon,
+    const scalar Cmu,
+    const scalar kMin,
+    const scalar epsilonMin,
+    word& error,
+    OperationStats* stats
+)
+{
+#ifdef FOAM_USE_CUDA
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return false;
+        }
+    }
+
+    const label nCells = nut.size();
+    if (nCells == 0)
+    {
+        error.clear();
+        return true;
+    }
+
+    if (k.size() != nCells || epsilon.size() != nCells)
+    {
+        error = "computeNut: field sizes do not match";
+        return false;
+    }
+
+    DeviceField<volScalarField>& nutMutable = nut;
+    DeviceField<volScalarField>& kMutable =
+        const_cast<DeviceField<volScalarField>&>(k);
+    DeviceField<volScalarField>& epsilonMutable =
+        const_cast<DeviceField<volScalarField>&>(epsilon);
+
+    nutMutable.markHostDirty();
+    kMutable.markHostDirty();
+    epsilonMutable.markHostDirty();
+
+    if
+    (
+        !nutMutable.syncHostToDevice(ctx, error)
+     || !kMutable.syncHostToDevice(ctx, error)
+     || !epsilonMutable.syncHostToDevice(ctx, error)
+    )
+    {
+        return false;
+    }
+
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+    if (!compileNutKernel(module, function, error))
+    {
+        return false;
+    }
+
+    double* nutPtr = reinterpret_cast<double*>(nutMutable.devicePointer());
+    double* kPtr = reinterpret_cast<double*>(kMutable.devicePointer());
+    double* epsPtr = reinterpret_cast<double*>(epsilonMutable.devicePointer());
+
+    if (!nutPtr || !kPtr || !epsPtr)
+    {
+        error = "computeNut: null device pointer";
+        return false;
+    }
+
+    double CmuVal = static_cast<double>(Cmu);
+    double kMinVal = static_cast<double>(kMin);
+    double epsMinVal = static_cast<double>(epsilonMin);
+    int cells = static_cast<int>(nCells);
+
+    void* args[] =
+    {
+        &nutPtr,
+        &kPtr,
+        &epsPtr,
+        &CmuVal,
+        &kMinVal,
+        &epsMinVal,
+        &cells
+    };
+
+    cudaEvent_t startEvent = nullptr;
+    cudaEvent_t stopEvent = nullptr;
+
+    if (stats)
+    {
+        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+        cudaEventRecord(startEvent, ctx.stream());
+    }
+
+    CUresult status = cuLaunchKernel
+    (
+        function,
+        (cells + 255)/256, 1, 1,
+        256, 1, 1,
+        0,
+        reinterpret_cast<CUstream>(ctx.stream()),
+        args,
+        nullptr
+    );
+
+    if (status != CUDA_SUCCESS)
+    {
+        error = "cuLaunchKernel(computeNut) failed: "
+          + cudaDriverErrorString(status);
+        return false;
+    }
+
+    if (stats)
+    {
+        cudaEventRecord(stopEvent, ctx.stream());
+        cudaEventSynchronize(stopEvent);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+        stats->gpuMilliseconds = static_cast<scalar>(ms);
+        cudaEventDestroy(startEvent);
+        cudaEventDestroy(stopEvent);
+    }
+    else
+    {
+        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
+        if (status != CUDA_SUCCESS)
+        {
+            error = "cuStreamSynchronize failed: "
+              + cudaDriverErrorString(status);
+            return false;
+        }
+    }
+
+    nutMutable.markDeviceDirty();
+    if (!nutMutable.syncDeviceToHost(ctx, error))
+    {
+        return false;
+    }
+
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)nut;
+    (void)k;
+    (void)epsilon;
+    (void)Cmu;
+    (void)kMin;
+    (void)epsilonMin;
+    (void)stats;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
 } // namespace gpu
 } // namespace Foam

--- a/src/gpuInfrastructure/FieldOps/FieldOps.C
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.C
@@ -1,0 +1,502 @@
+#include "FieldOps.H"
+#include "error.H"
+
+#include <string>
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda.h>
+    #include <cuda_runtime.h>
+    #include <nvrtc.h>
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+#ifdef FOAM_USE_CUDA
+namespace
+{
+
+std::string nvrtcErrorString(const nvrtcResult code)
+{
+    return std::string(nvrtcGetErrorString(code))
+        + " (" + Foam::name(static_cast<int>(code)) + ')';
+}
+
+
+std::string cudaDriverErrorString(const CUresult code)
+{
+    const char* msg = nullptr;
+    cuGetErrorString(code, &msg);
+    if (msg)
+    {
+        return std::string(msg)
+            + " (" + Foam::name(static_cast<int>(code)) + ')';
+    }
+    return "cuda driver error (" + Foam::name(static_cast<int>(code)) + ')';
+}
+
+
+bool compileSurfaceSubtractKernel(CUmodule& module, CUfunction& function, word& error)
+{
+    static bool initialised = false;
+    static CUmodule cachedModule = nullptr;
+    static CUfunction cachedFunction = nullptr;
+
+    if (initialised)
+    {
+        module = cachedModule;
+        function = cachedFunction;
+        error.clear();
+        return cachedModule != nullptr && cachedFunction != nullptr;
+    }
+
+    initialised = true;
+
+    const char* source = R"(
+extern "C" __global__
+void surfaceSubtract(double* dst, const double* a, const double* b, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        dst[idx] = a[idx] - b[idx];
+    }
+}
+)";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source,
+        "surfaceSubtract.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    const char* options[] = { "--std=c++14" };
+    nvStatus = nvrtcCompileProgram(prog, 1, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "surfaceSubtract");
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    module = cachedModule;
+    function = cachedFunction;
+    error.clear();
+    return true;
+}
+
+} // namespace
+#endif
+
+
+bool subtractSurfaceScalarFields
+(
+    Context& ctx,
+    DeviceField<surfaceScalarField>& dst,
+    const DeviceField<surfaceScalarField>& a,
+    const DeviceField<surfaceScalarField>& b,
+    word& error,
+    OperationStats* stats
+)
+{
+#ifdef FOAM_USE_CUDA
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return false;
+        }
+    }
+
+    if (!dst.allocated())
+    {
+        if (!dst.syncHostToDevice(ctx, error))
+        {
+            return false;
+        }
+    }
+
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+    if (!compileSurfaceSubtractKernel(module, function, error))
+    {
+        return false;
+    }
+
+    const label n = dst.size();
+    if (n == 0)
+    {
+        error.clear();
+        return true;
+    }
+
+    double* dstPtr = reinterpret_cast<double*>(dst.devicePointer());
+    double* aPtr = const_cast<double*>
+    (
+        reinterpret_cast<const double*>(a.devicePointer())
+    );
+    double* bPtr = const_cast<double*>
+    (
+        reinterpret_cast<const double*>(b.devicePointer())
+    );
+
+    if (!dstPtr || !aPtr || !bPtr)
+    {
+        error = "Device pointers are null";
+        return false;
+    }
+
+    int nCells = static_cast<int>(n);
+    const unsigned int blockSize = 256;
+    const unsigned int gridSize = (nCells + blockSize - 1)/blockSize;
+
+    void* args[] = { &dstPtr, &aPtr, &bPtr, &nCells };
+
+    cudaEvent_t startEvent = nullptr;
+    cudaEvent_t stopEvent = nullptr;
+
+    if (stats)
+    {
+        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+        cudaEventRecord(startEvent, ctx.stream());
+    }
+
+    CUresult status = cuLaunchKernel
+    (
+        function,
+        gridSize, 1, 1,
+        blockSize, 1, 1,
+        0,
+        reinterpret_cast<CUstream>(ctx.stream()),
+        args,
+        nullptr
+    );
+
+    if (status != CUDA_SUCCESS)
+    {
+        error = "cuLaunchKernel failed: " + cudaDriverErrorString(status);
+        return false;
+    }
+
+    if (stats)
+    {
+        cudaEventRecord(stopEvent, ctx.stream());
+        cudaEventSynchronize(stopEvent);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+
+        stats->gpuMilliseconds = static_cast<scalar>(ms);
+        cudaEventDestroy(startEvent);
+        cudaEventDestroy(stopEvent);
+    }
+    else
+    {
+        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
+        if (status != CUDA_SUCCESS)
+        {
+            error = "cuStreamSynchronize failed: " + cudaDriverErrorString(status);
+            return false;
+        }
+    }
+
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)dst;
+    (void)a;
+    (void)b;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+#ifdef FOAM_USE_CUDA
+bool compileVelocityCorrectorKernel(CUmodule& module, CUfunction& function, word& error)
+{
+    static bool initialised = false;
+    static CUmodule cachedModule = nullptr;
+    static CUfunction cachedFunction = nullptr;
+
+    if (initialised)
+    {
+        module = cachedModule;
+        function = cachedFunction;
+        error.clear();
+        return cachedModule != nullptr && cachedFunction != nullptr;
+    }
+
+    initialised = true;
+
+    const char* source = R"(
+extern "C" __global__
+void velocityCorrector(double* u, const double* h, const double* grad, const double* r, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        double rVal = r[idx];
+        int base = idx * 3;
+        u[base]     = h[base]     - rVal * grad[base];
+        u[base + 1] = h[base + 1] - rVal * grad[base + 1];
+        u[base + 2] = h[base + 2] - rVal * grad[base + 2];
+    }
+}
+)";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source,
+        "velocityCorrector.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    const char* options[] = { "--std=c++14" };
+    nvStatus = nvrtcCompileProgram(prog, 1, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    CUresult cuStatus = cuModuleLoadData(&cachedModule, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction(&cachedFunction, cachedModule, "velocityCorrector");
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cachedModule = nullptr;
+        cachedFunction = nullptr;
+        return false;
+    }
+
+    module = cachedModule;
+    function = cachedFunction;
+    error.clear();
+    return true;
+}
+#endif
+
+
+bool velocityCorrector
+(
+    Context& ctx,
+    DeviceField<volVectorField>& U,
+    const DeviceField<volVectorField>& HbyA,
+    const DeviceField<volScalarField>& rAtU,
+    const DeviceField<volVectorField>& gradP,
+    word& error,
+    OperationStats* stats
+)
+{
+#ifdef FOAM_USE_CUDA
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return false;
+        }
+    }
+
+    if (!U.allocated())
+    {
+        if (!U.syncHostToDevice(ctx, error))
+        {
+            return false;
+        }
+    }
+
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+    if (!compileVelocityCorrectorKernel(module, function, error))
+    {
+        return false;
+    }
+
+    const label n = U.size();
+    if (n == 0)
+    {
+        error.clear();
+        return true;
+    }
+
+    double* uPtr = reinterpret_cast<double*>(U.devicePointer());
+    double* hPtr = const_cast<double*>
+    (
+        reinterpret_cast<const double*>(HbyA.devicePointer())
+    );
+    double* gradPtr = const_cast<double*>
+    (
+        reinterpret_cast<const double*>(gradP.devicePointer())
+    );
+    double* rPtr = const_cast<double*>
+    (
+        reinterpret_cast<const double*>(rAtU.devicePointer())
+    );
+
+    if (!uPtr || !hPtr || !gradPtr || !rPtr)
+    {
+        error = "Device pointers are null";
+        return false;
+    }
+
+    int nCells = static_cast<int>(n);
+    const unsigned int blockSize = 256;
+    const unsigned int gridSize = (nCells + blockSize - 1)/blockSize;
+
+    void* args[] = { &uPtr, &hPtr, &gradPtr, &rPtr, &nCells };
+
+    cudaEvent_t startEvent = nullptr;
+    cudaEvent_t stopEvent = nullptr;
+
+    if (stats)
+    {
+        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+        cudaEventRecord(startEvent, ctx.stream());
+    }
+
+    CUresult status = cuLaunchKernel
+    (
+        function,
+        gridSize, 1, 1,
+        blockSize, 1, 1,
+        0,
+        reinterpret_cast<CUstream>(ctx.stream()),
+        args,
+        nullptr
+    );
+
+    if (status != CUDA_SUCCESS)
+    {
+        error = "cuLaunchKernel failed: " + cudaDriverErrorString(status);
+        return false;
+    }
+
+    if (stats)
+    {
+        cudaEventRecord(stopEvent, ctx.stream());
+        cudaEventSynchronize(stopEvent);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+
+        stats->gpuMilliseconds = static_cast<scalar>(ms);
+        cudaEventDestroy(startEvent);
+        cudaEventDestroy(stopEvent);
+    }
+    else
+    {
+        status = cuStreamSynchronize(reinterpret_cast<CUstream>(ctx.stream()));
+        if (status != CUDA_SUCCESS)
+        {
+            error = "cuStreamSynchronize failed: " + cudaDriverErrorString(status);
+            return false;
+        }
+    }
+
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)U;
+    (void)HbyA;
+    (void)rAtU;
+    (void)gradP;
+    (void)stats;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+} // namespace gpu
+} // namespace Foam

--- a/src/gpuInfrastructure/FieldOps/FieldOps.H
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.H
@@ -1,0 +1,45 @@
+#ifndef Foam_gpu_FieldOps_H
+#define Foam_gpu_FieldOps_H
+
+#include "DeviceField.H"
+#include "surfaceFields.H"
+#include "volFields.H"
+
+namespace Foam
+{
+namespace gpu
+{
+
+struct OperationStats
+{
+    scalar gpuMilliseconds{0};
+};
+
+//- Performs dst = a - b on the device (surface scalar fields).
+//  Returns true on success; on failure leaves error message and dst untouched.
+bool subtractSurfaceScalarFields
+(
+    Context& ctx,
+    DeviceField<surfaceScalarField>& dst,
+    const DeviceField<surfaceScalarField>& a,
+    const DeviceField<surfaceScalarField>& b,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
+//- Updates velocity via U = HbyA - rAtU * gradP using device data.
+bool velocityCorrector
+(
+    Context& ctx,
+    DeviceField<volVectorField>& U,
+    const DeviceField<volVectorField>& HbyA,
+    const DeviceField<volScalarField>& rAtU,
+    const DeviceField<volVectorField>& gradP,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
+} // namespace gpu
+} // namespace Foam
+
+#endif

--- a/src/gpuInfrastructure/FieldOps/FieldOps.H
+++ b/src/gpuInfrastructure/FieldOps/FieldOps.H
@@ -39,6 +39,20 @@ bool velocityCorrector
     OperationStats* stats = nullptr
 );
 
+//- Compute nut = Cmu * max(k,kMin)^2 / max(epsilon, epsilonMin) on device.
+bool computeNutFromKEpsilon
+(
+    Context& ctx,
+    DeviceField<volScalarField>& nut,
+    const DeviceField<volScalarField>& k,
+    const DeviceField<volScalarField>& epsilon,
+    const scalar Cmu,
+    const scalar kMin,
+    const scalar epsilonMin,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
 } // namespace gpu
 } // namespace Foam
 

--- a/src/gpuInfrastructure/FvOperators/FvOperators.C
+++ b/src/gpuInfrastructure/FvOperators/FvOperators.C
@@ -1,0 +1,1398 @@
+#include "FvOperators.H"
+#include "GpuContext.H"
+#include "DeviceField.H"
+#include "gaussConvectionScheme.H"
+#include "gaussLaplacianScheme.H"
+#include "convectionScheme.H"
+#include "laplacianScheme.H"
+#include "surfaceInterpolationScheme.H"
+#include "fvcSurfaceIntegrate.H"
+#include "fvcDiv.H"
+#include "fvc.H"
+#include "correctedSnGrad.H"
+#include "IStringStream.H"
+#include "surfaceInterpolate.H"
+#include "fvMesh.H"
+#include "fvMatrices.H"
+#include "Time.H"
+#include "pTraits.H"
+
+#include <sstream>
+#include <map>
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda.h>
+    #include <cuda_runtime.h>
+    #include <nvrtc.h>
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+namespace fvm
+{
+
+#ifdef FOAM_USE_CUDA
+namespace
+{
+
+std::string nvrtcErrorString(const nvrtcResult code)
+{
+    return std::string(nvrtcGetErrorString(code))
+        + " (" + Foam::name(static_cast<int>(code)) + ')';
+}
+
+
+std::string cudaDriverErrorString(const CUresult code)
+{
+    const char* msg = nullptr;
+    cuGetErrorString(code, &msg);
+    if (msg)
+    {
+        return std::string(msg)
+            + " (" + Foam::name(static_cast<int>(code)) + ')';
+    }
+    return "cuda driver error (" + Foam::name(static_cast<int>(code)) + ')';
+}
+
+
+struct KernelEntry
+{
+    CUmodule module{nullptr};
+    CUfunction function{nullptr};
+};
+
+
+bool compileEulerDdtKernel
+(
+    const int components,
+    CUmodule& module,
+    CUfunction& function,
+    word& error
+)
+{
+    static std::map<int, KernelEntry> cache;
+
+    const auto iter = cache.find(components);
+    if (iter != cache.end())
+    {
+        module = iter->second.module;
+        function = iter->second.function;
+        error.clear();
+        return module != nullptr && function != nullptr;
+    }
+
+    std::ostringstream source;
+    source
+        << "#define COMPONENTS " << components << '\n'
+        << "extern \"C\" __global__\n"
+        << "void assembleEulerDdt(\n"
+        << "    double* diag,\n"
+        << "    double* source,\n"
+        << "    const double* volumeDiag,\n"
+        << "    const double* volumeSource,\n"
+        << "    const double* fieldOld,\n"
+        << "    const double rDeltaT,\n"
+        << "    const int nCells)\n"
+        << "{\n"
+        << "    const int cell = blockIdx.x * blockDim.x + threadIdx.x;\n"
+        << "    if (cell >= nCells)\n"
+        << "    {\n"
+        << "        return;\n"
+        << "    }\n"
+        << "    const double diagVal = rDeltaT * volumeDiag[cell];\n"
+        << "    diag[cell] = diagVal;\n"
+        << "    const double coeff = rDeltaT * volumeSource[cell];\n"
+        << "    const double* uOld = fieldOld + cell*COMPONENTS;\n"
+        << "    double* src = source + cell*COMPONENTS;\n"
+        << "    #pragma unroll\n"
+        << "    for (int c = 0; c < COMPONENTS; ++c)\n"
+        << "    {\n"
+        << "        src[c] = coeff * uOld[c];\n"
+        << "    }\n"
+        << "}\n";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source.str().c_str(),
+        "assembleEulerDdt.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    KernelEntry entry;
+
+    CUresult cuStatus = cuModuleLoadData(&entry.module, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction
+    (
+        &entry.function,
+        entry.module,
+        "assembleEulerDdt"
+    );
+
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cuModuleUnload(entry.module);
+        entry = KernelEntry{};
+        return false;
+    }
+
+    cache.emplace(components, entry);
+    module = entry.module;
+    function = entry.function;
+    error.clear();
+    return true;
+}
+
+
+bool compileGaussDivKernel(CUmodule& module, CUfunction& function, word& error)
+{
+    static bool initialised = false;
+    static KernelEntry cache;
+
+    if (initialised)
+    {
+        module = cache.module;
+        function = cache.function;
+        error.clear();
+        return cache.module != nullptr && cache.function != nullptr;
+    }
+
+    initialised = true;
+
+    const char* source = R"(
+extern "C" __global__
+void assembleGaussDiv(double* lower, double* upper, const double* faceFlux, int nFaces)
+{
+    const int face = blockIdx.x * blockDim.x + threadIdx.x;
+    if (face >= nFaces)
+    {
+        return;
+    }
+
+    const double phi = faceFlux[face];
+    const double lowerVal = phi > 0.0 ? -phi : 0.0;
+    const double upperVal = lowerVal + phi;
+
+    lower[face] = lowerVal;
+    upper[face] = upperVal;
+}
+)";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source,
+        "assembleGaussDiv.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    CUresult cuStatus = cuModuleLoadData(&cache.module, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        cache = KernelEntry{};
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction
+    (
+        &cache.function,
+        cache.module,
+        "assembleGaussDiv"
+    );
+
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cuModuleUnload(cache.module);
+        cache = KernelEntry{};
+        return false;
+    }
+
+    module = cache.module;
+    function = cache.function;
+    error.clear();
+    return true;
+}
+
+bool compileGaussLaplacianKernel
+(
+    CUmodule& module,
+    CUfunction& function,
+    word& error
+)
+{
+    static bool initialised = false;
+    static KernelEntry cache;
+
+    if (initialised)
+    {
+        module = cache.module;
+        function = cache.function;
+        error.clear();
+        return cache.module != nullptr && cache.function != nullptr;
+    }
+
+    initialised = true;
+
+    const char* source = R"(
+extern "C" __global__
+void assembleGaussLaplacian(double* upper, const double* gammaMagSf, const double* deltaCoeffs, int nFaces)
+{
+    const int face = blockIdx.x * blockDim.x + threadIdx.x;
+    if (face >= nFaces)
+    {
+        return;
+    }
+
+    upper[face] = gammaMagSf[face]*deltaCoeffs[face];
+}
+)";
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source,
+        "assembleGaussLaplacian.cu",
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    int deviceId = 0;
+    cudaGetDevice(&deviceId);
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, deviceId);
+
+    std::ostringstream arch;
+    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
+    const std::string archStr = arch.str();
+    const char* options[] = { "--std=c++14", archStr.c_str() };
+    nvStatus = nvrtcCompileProgram(prog, 2, options);
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    CUresult cuStatus = cuModuleLoadData(&cache.module, ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        cache = KernelEntry{};
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction
+    (
+        &cache.function,
+        cache.module,
+        "assembleGaussLaplacian"
+    );
+
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cuModuleUnload(cache.module);
+        cache = KernelEntry{};
+        return false;
+    }
+
+    module = cache.module;
+    function = cache.function;
+    error.clear();
+    return true;
+}
+
+class DeviceBuffer
+{
+    void* ptr_;
+
+public:
+    DeviceBuffer() : ptr_(nullptr) {}
+
+    ~DeviceBuffer()
+    {
+        if (ptr_)
+        {
+            cudaFree(ptr_);
+        }
+    }
+
+    void* get() const { return ptr_; }
+
+    template<class T>
+    T* as() const { return reinterpret_cast<T*>(ptr_); }
+
+    bool allocate(std::size_t bytes, word& error)
+    {
+        if (ptr_)
+        {
+            cudaFree(ptr_);
+            ptr_ = nullptr;
+        }
+
+        if (!bytes)
+        {
+            return true;
+        }
+
+        cudaError_t status = cudaMalloc(&ptr_, bytes);
+        if (status != cudaSuccess)
+        {
+            error = "cudaMalloc failed";
+            ptr_ = nullptr;
+            return false;
+        }
+
+        return true;
+    }
+};
+
+} // namespace
+#endif
+
+
+template<class Type>
+tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> gammaSnGradCorrection
+(
+    const surfaceVectorField& SfGammaCorr,
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    const fvMesh& mesh = vf.mesh();
+
+    tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> tCorr
+    (
+        GeometricField<Type, fvsPatchField, surfaceMesh>::New
+        (
+            "gammaSnGradCorr(" + vf.name() + ')',
+            mesh,
+            SfGammaCorr.dimensions()
+           *vf.dimensions()
+           *mesh.deltaCoeffs().dimensions()
+        )
+    );
+
+    GeometricField<Type, fvsPatchField, surfaceMesh>& corr = tCorr.ref();
+
+    for (direction cmpt = 0; cmpt < pTraits<Type>::nComponents; ++cmpt)
+    {
+        corr.replace
+        (
+            cmpt,
+            fvc::dotInterpolate
+            (
+                SfGammaCorr,
+                fvc::grad(vf.component(cmpt))
+            )
+        );
+    }
+
+    return tCorr;
+}
+
+
+template<class Type>
+tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> correctedSnGradCorrection
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vf
+)
+{
+    const fvMesh& mesh = vf.mesh();
+
+    tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> tCorr
+    (
+        GeometricField<Type, fvsPatchField, surfaceMesh>::New
+        (
+            "snGradCorr(" + vf.name() + ')',
+            mesh,
+            vf.dimensions()*mesh.nonOrthDeltaCoeffs().dimensions()
+        )
+    );
+
+    GeometricField<Type, fvsPatchField, surfaceMesh>& corr = tCorr.ref();
+
+    for (direction cmpt = 0; cmpt < pTraits<Type>::nComponents; ++cmpt)
+    {
+        typedef typename pTraits<Type>::cmptType CmptType;
+        IStringStream emptyStream("");
+        fv::correctedSnGrad<CmptType> scheme(mesh, emptyStream);
+        corr.replace
+        (
+            cmpt,
+            scheme.fullGradCorrection(vf.component(cmpt))
+        );
+    }
+
+    return tCorr;
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type>> ddt
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats
+)
+{
+    usedGpu = false;
+    error.clear();
+
+#ifndef FOAM_USE_CUDA
+    error = "CUDA support not available";
+    return tmp<fvMatrix<Type>>();
+#else
+    const fvMesh& mesh = vf.mesh();
+    const word ddtKey("ddt(" + vf.name() + ')');
+    const word schemeName(mesh.schemes().ddt(ddtKey));
+
+    if (schemeName != "Euler")
+    {
+        error = "GPU ddt supports Euler scheme only (found " + schemeName + ")";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+    }
+
+    DeviceField<GeometricField<Type, fvPatchField, volMesh>>* vfDevicePtr =
+        nullptr;
+
+    DeviceField<GeometricField<Type, fvPatchField, volMesh>>* vfOldDevicePtr =
+        nullptr;
+
+    try
+    {
+        vfDevicePtr = &registry.getOrCreate(vf);
+        auto& vfOld =
+            const_cast<GeometricField<Type, fvPatchField, volMesh>&>
+            (
+                vf.oldTime()
+            );
+        vfOldDevicePtr = &registry.getOrCreate(vfOld);
+    }
+    catch (...)
+    {
+        error = "Failed to access device field wrappers for ddt";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    DeviceField<GeometricField<Type, fvPatchField, volMesh>>& vfDevice =
+        *vfDevicePtr;
+    DeviceField<GeometricField<Type, fvPatchField, volMesh>>& vfOldDevice =
+        *vfOldDevicePtr;
+
+    if (!vfDevice.syncHostToDevice(ctx, error))
+    {
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (!vfOldDevice.syncHostToDevice(ctx, error))
+    {
+        return tmp<fvMatrix<Type>>();
+    }
+
+    const label nCells = vf.internalField().size();
+
+    tmp<fvMatrix<Type>> tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            vf.dimensions()*dimVol/dimTime
+        )
+    );
+    fvMatrix<Type>& mat = tfvm.ref();
+
+    scalarField& diag = mat.diag();
+    Field<Type>& source = mat.source();
+
+    if (!nCells)
+    {
+        usedGpu = true;
+        return tfvm;
+    }
+
+    const scalar rDeltaT = 1.0/mesh.time().deltaTValue();
+    const scalarField& volumeDiag = mesh.Vsc();
+    const scalarField& volumeSource =
+        mesh.moving() ? mesh.Vsc0() : mesh.Vsc();
+
+    DeviceBuffer diagDev;
+    DeviceBuffer sourceDev;
+    DeviceBuffer volDiagDev;
+    DeviceBuffer volSrcDev;
+
+    const std::size_t diagBytes = sizeof(scalar)*nCells;
+    const std::size_t nComp = pTraits<Type>::nComponents;
+    const std::size_t sourceBytes = sizeof(scalar)*nCells*nComp;
+
+    if
+    (
+        !diagDev.allocate(diagBytes, error)
+     || !sourceDev.allocate(sourceBytes, error)
+     || !volDiagDev.allocate(diagBytes, error)
+     || !volSrcDev.allocate(diagBytes, error)
+    )
+    {
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (cudaMemcpy
+        (
+            volDiagDev.as<scalar>(),
+            volumeDiag.begin(),
+            diagBytes,
+            cudaMemcpyHostToDevice
+        ) != cudaSuccess)
+    {
+        error = "cudaMemcpy(volDiag host->device) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (cudaMemcpy
+        (
+            volSrcDev.as<scalar>(),
+            volumeSource.begin(),
+            diagBytes,
+            cudaMemcpyHostToDevice
+        ) != cudaSuccess)
+    {
+        error = "cudaMemcpy(volSrc host->device) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    CUmodule module = nullptr;
+    CUfunction function = nullptr;
+
+    if
+    (
+        !compileEulerDdtKernel(static_cast<int>(nComp), module, function, error)
+    )
+    {
+        return tmp<fvMatrix<Type>>();
+    }
+
+    scalar* diagPtr = reinterpret_cast<scalar*>(diagDev.get());
+    scalar* sourcePtr = reinterpret_cast<scalar*>(sourceDev.get());
+    scalar* volDiagPtr = reinterpret_cast<scalar*>(volDiagDev.get());
+    scalar* volSrcPtr = reinterpret_cast<scalar*>(volSrcDev.get());
+
+    scalar* vfOldPtr = reinterpret_cast<scalar*>
+    (
+        vfOldDevice.devicePointer()
+    );
+
+    if (!vfOldPtr)
+    {
+        error = "ddt: device pointer for old field is null";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    const unsigned int blockSize = 256;
+    const unsigned int gridSize = (nCells + blockSize - 1)/blockSize;
+
+    scalar coeff = rDeltaT;
+    int cells = static_cast<int>(nCells);
+
+    void* args[] =
+    {
+        &diagPtr,
+        &sourcePtr,
+        &volDiagPtr,
+        &volSrcPtr,
+        &vfOldPtr,
+        &coeff,
+        &cells
+    };
+
+    cudaEvent_t startEvent = nullptr;
+    cudaEvent_t stopEvent = nullptr;
+
+    if (stats)
+    {
+        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+        cudaEventRecord(startEvent, ctx.stream());
+    }
+
+    CUresult launchStatus = cuLaunchKernel
+    (
+        function,
+        gridSize, 1, 1,
+        blockSize, 1, 1,
+        0,
+        reinterpret_cast<CUstream>(ctx.stream()),
+        args,
+        nullptr
+    );
+
+    if (launchStatus != CUDA_SUCCESS)
+    {
+        error = "cuLaunchKernel(assembleEulerDdt) failed: "
+            + cudaDriverErrorString(launchStatus);
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (stats)
+    {
+        cudaEventRecord(stopEvent, ctx.stream());
+        cudaEventSynchronize(stopEvent);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+        stats->gpuMilliseconds = static_cast<scalar>(ms);
+        cudaEventDestroy(startEvent);
+        cudaEventDestroy(stopEvent);
+    }
+    else
+    {
+        launchStatus = cuStreamSynchronize
+        (
+            reinterpret_cast<CUstream>(ctx.stream())
+        );
+
+        if (launchStatus != CUDA_SUCCESS)
+        {
+            error = "cuStreamSynchronize failed: "
+              + cudaDriverErrorString(launchStatus);
+            return tmp<fvMatrix<Type>>();
+        }
+    }
+
+    if
+    (
+        cudaMemcpy
+        (
+            diag.begin(),
+            diagPtr,
+            diagBytes,
+            cudaMemcpyDeviceToHost
+        ) != cudaSuccess
+    )
+    {
+        error = "cudaMemcpy(diag device->host) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    scalar* sourceHost = reinterpret_cast<scalar*>(source.begin());
+    if
+    (
+        cudaMemcpy
+        (
+            sourceHost,
+            sourcePtr,
+            sourceBytes,
+            cudaMemcpyDeviceToHost
+        ) != cudaSuccess
+    )
+    {
+        error = "cudaMemcpy(source device->host) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    usedGpu = true;
+    error.clear();
+    return tfvm;
+#endif
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type>> laplacian
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    const GeometricField<scalar, fvPatchField, volMesh>& gamma,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats
+)
+{
+    (void)registry;
+    usedGpu = false;
+    error.clear();
+
+#ifndef FOAM_USE_CUDA
+    error = "CUDA support not available";
+    return tmp<fvMatrix<Type>>();
+#else
+    const fvMesh& mesh = vf.mesh();
+    const word lapName("laplacian(" + gamma.name() + ',' + vf.name() + ')');
+
+    ITstream& schemeStream = mesh.schemes().laplacian(lapName);
+    word schemeType(schemeStream);
+    if (schemeType != "Gauss")
+    {
+        error = "GPU laplacian supports Gauss schemes only (found "
+          + schemeType + ')';
+        return tmp<fvMatrix<Type>>();
+    }
+
+    word interpolationName("linear");
+    if (!schemeStream.eof())
+    {
+        interpolationName = word(schemeStream);
+    }
+
+    word snGradName("corrected");
+    if (!schemeStream.eof())
+    {
+        snGradName = word(schemeStream);
+    }
+
+    if (interpolationName != "linear")
+    {
+        error = "GPU laplacian supports Gauss linear only (found "
+          + interpolationName + ')';
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if
+    (
+        snGradName != "corrected"
+     && snGradName != "uncorrected"
+    )
+    {
+        error = "GPU laplacian supports corrected/uncorrected snGrad only"
+            " (found " + snGradName + ')';
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+    }
+
+    tmp<surfaceScalarField> tGammaFace = fvc::interpolate(gamma);
+    const surfaceScalarField& gammaFace = tGammaFace();
+    const surfaceScalarField& magSf = mesh.magSf();
+
+    tmp<surfaceScalarField> tGammaMagSf(gammaFace*magSf);
+    const surfaceScalarField& gammaMagSf = tGammaMagSf();
+
+    const surfaceScalarField& deltaCoeffsRef =
+        (snGradName == "corrected")
+      ? mesh.nonOrthDeltaCoeffs()
+      : mesh.deltaCoeffs();
+
+    tmp<fvMatrix<Type>> tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            deltaCoeffsRef.dimensions()*gammaMagSf.dimensions()*vf.dimensions()
+        )
+    );
+    fvMatrix<Type>& mat = tfvm.ref();
+
+    scalarField& upper = mat.upper();
+
+    const label nFaces = mesh.nInternalFaces();
+
+    if (nFaces)
+    {
+        DeviceBuffer gammaDev;
+        DeviceBuffer deltaDev;
+        DeviceBuffer upperDev;
+
+        const std::size_t bytes = sizeof(scalar)*nFaces;
+
+        if
+        (
+            !gammaDev.allocate(bytes, error)
+         || !deltaDev.allocate(bytes, error)
+         || !upperDev.allocate(bytes, error)
+        )
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                gammaDev.get(),
+                gammaMagSf.primitiveField().begin(),
+                bytes,
+                cudaMemcpyHostToDevice
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpy(gammaMagSf host->device) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                deltaDev.get(),
+                deltaCoeffsRef.primitiveField().begin(),
+                bytes,
+                cudaMemcpyHostToDevice
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpy(deltaCoeffs host->device) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        CUmodule module = nullptr;
+        CUfunction function = nullptr;
+
+        if (!compileGaussLaplacianKernel(module, function, error))
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+
+        double* upperPtr = reinterpret_cast<double*>(upperDev.get());
+        double* gammaPtr = reinterpret_cast<double*>(gammaDev.get());
+        double* deltaPtr = reinterpret_cast<double*>(deltaDev.get());
+
+        int faces = static_cast<int>(nFaces);
+        void* args[] = { &upperPtr, &gammaPtr, &deltaPtr, &faces };
+
+        cudaEvent_t startEvent = nullptr;
+        cudaEvent_t stopEvent = nullptr;
+
+        if (stats)
+        {
+            cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+            cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+            cudaEventRecord(startEvent, ctx.stream());
+        }
+
+        CUresult launchStatus = cuLaunchKernel
+        (
+            function,
+            (faces + 255)/256, 1, 1,
+            256, 1, 1,
+            0,
+            reinterpret_cast<CUstream>(ctx.stream()),
+            args,
+            nullptr
+        );
+
+        if (launchStatus != CUDA_SUCCESS)
+        {
+            error = "cuLaunchKernel(assembleGaussLaplacian) failed: "
+              + cudaDriverErrorString(launchStatus);
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if (stats)
+        {
+            cudaEventRecord(stopEvent, ctx.stream());
+            cudaEventSynchronize(stopEvent);
+
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, startEvent, stopEvent);
+            stats->gpuMilliseconds = static_cast<scalar>(ms);
+            cudaEventDestroy(startEvent);
+            cudaEventDestroy(stopEvent);
+        }
+        else
+        {
+            launchStatus = cuStreamSynchronize
+            (
+                reinterpret_cast<CUstream>(ctx.stream())
+            );
+
+            if (launchStatus != CUDA_SUCCESS)
+            {
+                error = "cuStreamSynchronize failed: "
+                  + cudaDriverErrorString(launchStatus);
+                return tmp<fvMatrix<Type>>();
+            }
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                upper.begin(),
+                upperDev.get(),
+                bytes,
+                cudaMemcpyDeviceToHost
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpy(upper device->host) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+    }
+    else if (stats)
+    {
+        stats->gpuMilliseconds = 0;
+    }
+
+    mat.negSumDiag();
+
+    forAll(vf.boundaryField(), patchi)
+    {
+        const fvPatchField<Type>& pvf = vf.boundaryField()[patchi];
+        const fvsPatchScalarField& pGamma = gammaMagSf.boundaryField()[patchi];
+        const fvsPatchScalarField& pDelta =
+            deltaCoeffsRef.boundaryField()[patchi];
+
+        if (pvf.coupled())
+        {
+            mat.internalCoeffs()[patchi] =
+                pGamma*pvf.gradientInternalCoeffs(pDelta);
+            mat.boundaryCoeffs()[patchi] =
+               -pGamma*pvf.gradientBoundaryCoeffs(pDelta);
+        }
+        else
+        {
+            mat.internalCoeffs()[patchi] = pGamma*pvf.gradientInternalCoeffs();
+            mat.boundaryCoeffs()[patchi] =
+               -pGamma*pvf.gradientBoundaryCoeffs();
+        }
+    }
+
+    const surfaceVectorField& Sf = mesh.Sf();
+    const surfaceVectorField Sn = Sf/mesh.magSf();
+
+    tmp<surfaceVectorField> tSfGamma(Sf*gammaFace);
+    const surfaceVectorField& SfGamma = tSfGamma();
+
+    tmp<surfaceScalarField> tSfGammaSn = SfGamma & Sn;
+    const surfaceScalarField& SfGammaSn = tSfGammaSn();
+
+    surfaceVectorField SfGammaCorr(SfGamma - Sn*SfGammaSn);
+
+    tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> tFaceFluxCorrection =
+        gammaSnGradCorrection(SfGammaCorr, vf);
+
+    if (snGradName == "corrected")
+    {
+        tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> tSnGradCorr =
+            correctedSnGradCorrection(vf);
+        tFaceFluxCorrection.ref() += SfGammaSn*tSnGradCorr();
+    }
+
+    mat.source() -=
+        mesh.V()
+       *fvc::div(tFaceFluxCorrection())().primitiveField();
+
+    if (mesh.schemes().fluxRequired(vf.name()))
+    {
+        mat.faceFluxCorrectionPtr() = tFaceFluxCorrection.ptr();
+    }
+
+    usedGpu = true;
+    error.clear();
+    return tfvm;
+#endif
+}
+
+
+template<class Type>
+tmp<fvMatrix<Type>> div
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    const surfaceScalarField& faceFlux,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats
+)
+{
+    usedGpu = false;
+    error.clear();
+
+#ifndef FOAM_USE_CUDA
+    error = "CUDA support not available";
+    return tmp<fvMatrix<Type>>();
+#else
+    const fvMesh& mesh = vf.mesh();
+    const word divName("div(" + faceFlux.name() + ',' + vf.name() + ')');
+
+    tmp<fv::convectionScheme<Type>> tScheme =
+        fv::convectionScheme<Type>::New
+        (
+            mesh,
+            faceFlux,
+            mesh.schemes().div(divName)
+        );
+
+    fv::convectionScheme<Type>& scheme = tScheme.ref();
+
+    const fv::gaussConvectionScheme<Type>* gaussScheme =
+        dynamic_cast<fv::gaussConvectionScheme<Type>*>(&scheme);
+
+    if (!gaussScheme)
+    {
+        error =
+            "GPU div supports Gauss schemes only (found "
+          + scheme.type() + ')';
+        return tmp<fvMatrix<Type>>();
+    }
+
+    const surfaceInterpolationScheme<Type>& interp = gaussScheme->interpScheme();
+    tmp<surfaceScalarField> tweights = interp.weights(vf);
+    const surfaceScalarField& weights = tweights();
+
+    tmp<fvMatrix<Type>> tfvm
+    (
+        new fvMatrix<Type>
+        (
+            vf,
+            faceFlux.dimensions()*vf.dimensions()
+        )
+    );
+    fvMatrix<Type>& mat = tfvm.ref();
+
+    scalarField& lower = mat.lower();
+    scalarField& upper = mat.upper();
+
+    const label nFaces = mesh.nInternalFaces();
+
+    if (nFaces)
+    {
+        DeviceField<surfaceScalarField>& fluxDev =
+            registry.getOrCreate(const_cast<surfaceScalarField&>(faceFlux));
+
+        if (!fluxDev.syncHostToDevice(ctx, error))
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+
+        DeviceBuffer lowerDev;
+        DeviceBuffer upperDev;
+
+        if
+        (
+            !lowerDev.allocate(sizeof(scalar)*nFaces, error)
+         || !upperDev.allocate(sizeof(scalar)*nFaces, error)
+        )
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+
+        CUmodule module = nullptr;
+        CUfunction function = nullptr;
+
+        if (!compileGaussDivKernel(module, function, error))
+        {
+            return tmp<fvMatrix<Type>>();
+        }
+
+        double* lowerPtr = reinterpret_cast<double*>(lowerDev.get());
+        double* upperPtr = reinterpret_cast<double*>(upperDev.get());
+        double* fluxPtr = reinterpret_cast<double*>(fluxDev.devicePointer());
+
+        if (!fluxPtr)
+        {
+            error = "GPU div: device pointer for face flux is null";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        int faces = static_cast<int>(nFaces);
+        void* args[] = { &lowerPtr, &upperPtr, &fluxPtr, &faces };
+
+        cudaEvent_t startEvent = nullptr;
+        cudaEvent_t stopEvent = nullptr;
+
+        if (stats)
+        {
+            cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
+            cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
+            cudaEventRecord(startEvent, ctx.stream());
+        }
+
+        CUresult launchStatus = cuLaunchKernel
+        (
+            function,
+            (faces + 255)/256, 1, 1,
+            256, 1, 1,
+            0,
+            reinterpret_cast<CUstream>(ctx.stream()),
+            args,
+            nullptr
+        );
+
+        if (launchStatus != CUDA_SUCCESS)
+        {
+            error = "cuLaunchKernel(assembleGaussDiv) failed: "
+              + cudaDriverErrorString(launchStatus);
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if (stats)
+        {
+            cudaEventRecord(stopEvent, ctx.stream());
+            cudaEventSynchronize(stopEvent);
+
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, startEvent, stopEvent);
+            stats->gpuMilliseconds = static_cast<scalar>(ms);
+            cudaEventDestroy(startEvent);
+            cudaEventDestroy(stopEvent);
+        }
+        else
+        {
+            launchStatus = cuStreamSynchronize
+            (
+                reinterpret_cast<CUstream>(ctx.stream())
+            );
+
+            if (launchStatus != CUDA_SUCCESS)
+            {
+                error = "cuStreamSynchronize failed: "
+                  + cudaDriverErrorString(launchStatus);
+                return tmp<fvMatrix<Type>>();
+            }
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                lower.begin(),
+                lowerDev.get(),
+                sizeof(scalar)*nFaces,
+                cudaMemcpyDeviceToHost
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpy(lower device->host) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if
+        (
+            cudaMemcpy
+            (
+                upper.begin(),
+                upperDev.get(),
+                sizeof(scalar)*nFaces,
+                cudaMemcpyDeviceToHost
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpy(upper device->host) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+    }
+    else if (stats)
+    {
+        stats->gpuMilliseconds = 0;
+    }
+
+    mat.negSumDiag();
+
+    forAll(vf.boundaryField(), patchi)
+    {
+        const fvPatchField<Type>& psf = vf.boundaryField()[patchi];
+        const fvsPatchScalarField& patchFlux = faceFlux.boundaryField()[patchi];
+        const fvsPatchScalarField& pw = weights.boundaryField()[patchi];
+
+        mat.internalCoeffs()[patchi] =
+            patchFlux*psf.valueInternalCoeffs(pw);
+        mat.boundaryCoeffs()[patchi] =
+           -patchFlux*psf.valueBoundaryCoeffs(pw);
+    }
+
+    if (interp.corrected())
+    {
+        tmp<GeometricField<Type, fvsPatchField, surfaceMesh>> tcorr =
+            interp.correction(vf);
+
+        mat += fvc::surfaceIntegrate(faceFlux*tcorr());
+    }
+
+    usedGpu = true;
+    error.clear();
+    return tfvm;
+#endif
+}
+
+// Explicit instantiations for scalar and vector fields used in pimpleFoamGPU.
+template tmp<fvMatrix<scalar>> ddt
+(
+    Context&,
+    FieldRegistry&,
+    GeometricField<scalar, fvPatchField, volMesh>&,
+    bool&,
+    word&,
+    OperationStats*
+);
+
+template tmp<fvMatrix<vector>> ddt
+(
+    Context&,
+    FieldRegistry&,
+    GeometricField<vector, fvPatchField, volMesh>&,
+    bool&,
+    word&,
+    OperationStats*
+);
+
+template tmp<fvMatrix<vector>> div
+(
+    Context&,
+    FieldRegistry&,
+    const surfaceScalarField&,
+    GeometricField<vector, fvPatchField, volMesh>&,
+    bool&,
+    word&,
+    OperationStats*
+);
+
+template tmp<fvMatrix<scalar>> laplacian
+(
+    Context&,
+    FieldRegistry&,
+    const GeometricField<scalar, fvPatchField, volMesh>&,
+    GeometricField<scalar, fvPatchField, volMesh>&,
+    bool&,
+    word&,
+    OperationStats*
+);
+
+} // namespace fvm
+} // namespace gpu
+} // namespace Foam

--- a/src/gpuInfrastructure/FvOperators/FvOperators.C
+++ b/src/gpuInfrastructure/FvOperators/FvOperators.C
@@ -12,13 +12,15 @@
 #include "correctedSnGrad.H"
 #include "IStringStream.H"
 #include "surfaceInterpolate.H"
+#include "localEulerDdtScheme.H"
+#include "fvmLaplacian.H"
 #include "fvMesh.H"
 #include "fvMatrices.H"
 #include "Time.H"
 #include "pTraits.H"
+#include "KernelCache.H"
 
 #include <sstream>
-#include <map>
 
 #ifdef FOAM_USE_CUDA
     #include <cuda.h>
@@ -37,52 +39,14 @@ namespace fvm
 namespace
 {
 
-std::string nvrtcErrorString(const nvrtcResult code)
+word makeEulerDdtKey(const int components)
 {
-    return std::string(nvrtcGetErrorString(code))
-        + " (" + Foam::name(static_cast<int>(code)) + ')';
+    return word("assembleEulerDdt_" + Foam::name(components));
 }
 
 
-std::string cudaDriverErrorString(const CUresult code)
+std::string makeEulerDdtSource(const int components)
 {
-    const char* msg = nullptr;
-    cuGetErrorString(code, &msg);
-    if (msg)
-    {
-        return std::string(msg)
-            + " (" + Foam::name(static_cast<int>(code)) + ')';
-    }
-    return "cuda driver error (" + Foam::name(static_cast<int>(code)) + ')';
-}
-
-
-struct KernelEntry
-{
-    CUmodule module{nullptr};
-    CUfunction function{nullptr};
-};
-
-
-bool compileEulerDdtKernel
-(
-    const int components,
-    CUmodule& module,
-    CUfunction& function,
-    word& error
-)
-{
-    static std::map<int, KernelEntry> cache;
-
-    const auto iter = cache.find(components);
-    if (iter != cache.end())
-    {
-        module = iter->second.module;
-        function = iter->second.function;
-        error.clear();
-        return module != nullptr && function != nullptr;
-    }
-
     std::ostringstream source;
     source
         << "#define COMPONENTS " << components << '\n'
@@ -92,8 +56,8 @@ bool compileEulerDdtKernel
         << "    double* source,\n"
         << "    const double* volumeDiag,\n"
         << "    const double* volumeSource,\n"
+        << "    const double* rDeltaT,\n"
         << "    const double* fieldOld,\n"
-        << "    const double rDeltaT,\n"
         << "    const int nCells)\n"
         << "{\n"
         << "    const int cell = blockIdx.x * blockDim.x + threadIdx.x;\n"
@@ -101,9 +65,10 @@ bool compileEulerDdtKernel
         << "    {\n"
         << "        return;\n"
         << "    }\n"
-        << "    const double diagVal = rDeltaT * volumeDiag[cell];\n"
+        << "    const double rDeltaTCell = rDeltaT[cell];\n"
+        << "    const double diagVal = rDeltaTCell * volumeDiag[cell];\n"
         << "    diag[cell] = diagVal;\n"
-        << "    const double coeff = rDeltaT * volumeSource[cell];\n"
+        << "    const double coeff = rDeltaTCell * volumeSource[cell];\n"
         << "    const double* uOld = fieldOld + cell*COMPONENTS;\n"
         << "    double* src = source + cell*COMPONENTS;\n"
         << "    #pragma unroll\n"
@@ -112,108 +77,13 @@ bool compileEulerDdtKernel
         << "        src[c] = coeff * uOld[c];\n"
         << "    }\n"
         << "}\n";
-
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source.str().c_str(),
-        "assembleEulerDdt.cu",
-        0,
-        nullptr,
-        nullptr
-    );
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
-    }
-
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
-        {
-            nvrtcGetProgramLog(prog, &log[0]);
-        }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    KernelEntry entry;
-
-    CUresult cuStatus = cuModuleLoadData(&entry.module, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction
-    (
-        &entry.function,
-        entry.module,
-        "assembleEulerDdt"
-    );
-
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cuModuleUnload(entry.module);
-        entry = KernelEntry{};
-        return false;
-    }
-
-    cache.emplace(components, entry);
-    module = entry.module;
-    function = entry.function;
-    error.clear();
-    return true;
+    return source.str();
 }
 
 
-bool compileGaussDivKernel(CUmodule& module, CUfunction& function, word& error)
+const std::string& gaussDivSource()
 {
-    static bool initialised = false;
-    static KernelEntry cache;
-
-    if (initialised)
-    {
-        module = cache.module;
-        function = cache.function;
-        error.clear();
-        return cache.module != nullptr && cache.function != nullptr;
-    }
-
-    initialised = true;
-
-    const char* source = R"(
+    static const std::string src = R"(
 extern "C" __global__
 void assembleGaussDiv(double* lower, double* upper, const double* faceFlux, int nFaces)
 {
@@ -231,110 +101,13 @@ void assembleGaussDiv(double* lower, double* upper, const double* faceFlux, int 
     upper[face] = upperVal;
 }
 )";
-
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source,
-        "assembleGaussDiv.cu",
-        0,
-        nullptr,
-        nullptr
-    );
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
-    }
-
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
-        {
-            nvrtcGetProgramLog(prog, &log[0]);
-        }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    CUresult cuStatus = cuModuleLoadData(&cache.module, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        cache = KernelEntry{};
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction
-    (
-        &cache.function,
-        cache.module,
-        "assembleGaussDiv"
-    );
-
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cuModuleUnload(cache.module);
-        cache = KernelEntry{};
-        return false;
-    }
-
-    module = cache.module;
-    function = cache.function;
-    error.clear();
-    return true;
+    return src;
 }
 
-bool compileGaussLaplacianKernel
-(
-    CUmodule& module,
-    CUfunction& function,
-    word& error
-)
+
+const std::string& gaussLaplacianSource()
 {
-    static bool initialised = false;
-    static KernelEntry cache;
-
-    if (initialised)
-    {
-        module = cache.module;
-        function = cache.function;
-        error.clear();
-        return cache.module != nullptr && cache.function != nullptr;
-    }
-
-    initialised = true;
-
-    const char* source = R"(
+    static const std::string src = R"(
 extern "C" __global__
 void assembleGaussLaplacian(double* upper, const double* gammaMagSf, const double* deltaCoeffs, int nFaces)
 {
@@ -347,88 +120,9 @@ void assembleGaussLaplacian(double* upper, const double* gammaMagSf, const doubl
     upper[face] = gammaMagSf[face]*deltaCoeffs[face];
 }
 )";
-
-    nvrtcProgram prog;
-    nvrtcResult nvStatus = nvrtcCreateProgram
-    (
-        &prog,
-        source,
-        "assembleGaussLaplacian.cu",
-        0,
-        nullptr,
-        nullptr
-    );
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
-        return false;
-    }
-
-    int deviceId = 0;
-    cudaGetDevice(&deviceId);
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, deviceId);
-
-    std::ostringstream arch;
-    arch<< "--gpu-architecture=compute_" << prop.major << prop.minor;
-    const std::string archStr = arch.str();
-    const char* options[] = { "--std=c++14", archStr.c_str() };
-    nvStatus = nvrtcCompileProgram(prog, 2, options);
-
-    if (nvStatus != NVRTC_SUCCESS)
-    {
-        size_t logSize = 0;
-        nvrtcGetProgramLogSize(prog, &logSize);
-        std::string log(logSize, '\0');
-        if (logSize > 1)
-        {
-            nvrtcGetProgramLog(prog, &log[0]);
-        }
-
-        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
-        if (!log.empty())
-        {
-            error += " :: " + log;
-        }
-        nvrtcDestroyProgram(&prog);
-        return false;
-    }
-
-    size_t ptxSize = 0;
-    nvrtcGetPTXSize(prog, &ptxSize);
-    std::string ptx(ptxSize, '\0');
-    nvrtcGetPTX(prog, &ptx[0]);
-    nvrtcDestroyProgram(&prog);
-
-    CUresult cuStatus = cuModuleLoadData(&cache.module, ptx.c_str());
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
-        cache = KernelEntry{};
-        return false;
-    }
-
-    cuStatus = cuModuleGetFunction
-    (
-        &cache.function,
-        cache.module,
-        "assembleGaussLaplacian"
-    );
-
-    if (cuStatus != CUDA_SUCCESS)
-    {
-        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
-        cuModuleUnload(cache.module);
-        cache = KernelEntry{};
-        return false;
-    }
-
-    module = cache.module;
-    function = cache.function;
-    error.clear();
-    return true;
+    return src;
 }
+
 
 class DeviceBuffer
 {
@@ -618,6 +312,10 @@ tmp<fvMatrix<Type>> ddt
     DeviceField<GeometricField<Type, fvPatchField, volMesh>>& vfOldDevice =
         *vfOldDevicePtr;
 
+    // Ensure the old-time field values are uploaded for this step since
+    // OpenFOAM rotates them on the host each time step.
+    vfOldDevice.markHostDirty();
+
     if (!vfDevice.syncHostToDevice(ctx, error))
     {
         return tmp<fvMatrix<Type>>();
@@ -649,15 +347,26 @@ tmp<fvMatrix<Type>> ddt
         return tfvm;
     }
 
-    const scalar rDeltaT = 1.0/mesh.time().deltaTValue();
     const scalarField& volumeDiag = mesh.Vsc();
     const scalarField& volumeSource =
         mesh.moving() ? mesh.Vsc0() : mesh.Vsc();
+
+    scalarField rDeltaTHost
+    (
+        volumeDiag.size(),
+        1.0/mesh.time().deltaTValue()
+    );
+
+    if (fv::localEulerDdt::enabled(mesh))
+    {
+        rDeltaTHost = fv::localEulerDdt::localRDeltaT(mesh).primitiveField();
+    }
 
     DeviceBuffer diagDev;
     DeviceBuffer sourceDev;
     DeviceBuffer volDiagDev;
     DeviceBuffer volSrcDev;
+    DeviceBuffer rDeltaTDev;
 
     const std::size_t diagBytes = sizeof(scalar)*nCells;
     const std::size_t nComp = pTraits<Type>::nComponents;
@@ -669,43 +378,66 @@ tmp<fvMatrix<Type>> ddt
      || !sourceDev.allocate(sourceBytes, error)
      || !volDiagDev.allocate(diagBytes, error)
      || !volSrcDev.allocate(diagBytes, error)
+     || !rDeltaTDev.allocate(diagBytes, error)
     )
     {
         return tmp<fvMatrix<Type>>();
     }
 
-    if (cudaMemcpy
+    if
+    (
+        cudaMemcpyAsync
         (
             volDiagDev.as<scalar>(),
             volumeDiag.begin(),
             diagBytes,
-            cudaMemcpyHostToDevice
-        ) != cudaSuccess)
+            cudaMemcpyHostToDevice,
+            ctx.transferStream()
+        ) != cudaSuccess
+    )
     {
-        error = "cudaMemcpy(volDiag host->device) failed";
+        error = "cudaMemcpyAsync(volDiag host->device) failed";
         return tmp<fvMatrix<Type>>();
     }
 
-    if (cudaMemcpy
+    if
+    (
+        cudaMemcpyAsync
         (
             volSrcDev.as<scalar>(),
             volumeSource.begin(),
             diagBytes,
-            cudaMemcpyHostToDevice
-        ) != cudaSuccess)
+            cudaMemcpyHostToDevice,
+            ctx.transferStream()
+        ) != cudaSuccess
+    )
     {
-        error = "cudaMemcpy(volSrc host->device) failed";
+        error = "cudaMemcpyAsync(volSrc host->device) failed";
         return tmp<fvMatrix<Type>>();
     }
 
-    CUmodule module = nullptr;
-    CUfunction function = nullptr;
+    if
+    (
+        cudaMemcpyAsync
+        (
+            rDeltaTDev.as<scalar>(),
+            rDeltaTHost.begin(),
+            diagBytes,
+            cudaMemcpyHostToDevice,
+            ctx.transferStream()
+        ) != cudaSuccess
+    )
+    {
+        error = "cudaMemcpyAsync(rDeltaT host->device) failed";
+        return tmp<fvMatrix<Type>>();
+    }
 
     if
     (
-        !compileEulerDdtKernel(static_cast<int>(nComp), module, function, error)
+        cudaStreamSynchronize(ctx.transferStream()) != cudaSuccess
     )
     {
+        error = "cudaStreamSynchronize(volCoeff host->device) failed";
         return tmp<fvMatrix<Type>>();
     }
 
@@ -713,6 +445,7 @@ tmp<fvMatrix<Type>> ddt
     scalar* sourcePtr = reinterpret_cast<scalar*>(sourceDev.get());
     scalar* volDiagPtr = reinterpret_cast<scalar*>(volDiagDev.get());
     scalar* volSrcPtr = reinterpret_cast<scalar*>(volSrcDev.get());
+    scalar* rDeltaTPtr = reinterpret_cast<scalar*>(rDeltaTDev.get());
 
     scalar* vfOldPtr = reinterpret_cast<scalar*>
     (
@@ -728,7 +461,6 @@ tmp<fvMatrix<Type>> ddt
     const unsigned int blockSize = 256;
     const unsigned int gridSize = (nCells + blockSize - 1)/blockSize;
 
-    scalar coeff = rDeltaT;
     int cells = static_cast<int>(nCells);
 
     void* args[] =
@@ -737,93 +469,134 @@ tmp<fvMatrix<Type>> ddt
         &sourcePtr,
         &volDiagPtr,
         &volSrcPtr,
+        &rDeltaTPtr,
         &vfOldPtr,
-        &coeff,
         &cells
     };
 
-    cudaEvent_t startEvent = nullptr;
-    cudaEvent_t stopEvent = nullptr;
+    const int components = static_cast<int>(nComp);
+    const word kernelKey = makeEulerDdtKey(components);
+    const std::string kernelSource = makeEulerDdtSource(components);
 
-    if (stats)
+    CompiledKernel kernel;
+    if
+    (
+        !KernelCache::instance().getOrCompile
+        (
+            ctx,
+            kernelKey,
+            kernelSource,
+            {},
+            "assembleEulerDdt",
+            kernel,
+            error
+        )
+    )
     {
-        cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-        cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-        cudaEventRecord(startEvent, ctx.stream());
+        return tmp<fvMatrix<Type>>();
     }
 
-    CUresult launchStatus = cuLaunchKernel
-    (
-        function,
-        gridSize, 1, 1,
-        blockSize, 1, 1,
-        0,
-        reinterpret_cast<CUstream>(ctx.stream()),
-        args,
-        nullptr
-    );
+    scalar elapsedMs = 0;
 
-    if (launchStatus != CUDA_SUCCESS)
+    if
+    (
+        !GraphLaunchCache::instance().launch
+        (
+            ctx,
+            kernelKey,
+            kernel,
+            StreamCategory::compute,
+            dim3(gridSize, 1, 1),
+            dim3(blockSize, 1, 1),
+            args,
+            sizeof(args)/sizeof(args[0]),
+            0,
+            error,
+            stats != nullptr,
+            elapsedMs
+        )
+    )
     {
-        error = "cuLaunchKernel(assembleEulerDdt) failed: "
-            + cudaDriverErrorString(launchStatus);
         return tmp<fvMatrix<Type>>();
     }
 
     if (stats)
     {
-        cudaEventRecord(stopEvent, ctx.stream());
-        cudaEventSynchronize(stopEvent);
-
-        float ms = 0.0f;
-        cudaEventElapsedTime(&ms, startEvent, stopEvent);
-        stats->gpuMilliseconds = static_cast<scalar>(ms);
-        cudaEventDestroy(startEvent);
-        cudaEventDestroy(stopEvent);
+        stats->gpuMilliseconds = elapsedMs;
     }
-    else
+
+    cudaEvent_t kernelDone = nullptr;
+    if (cudaEventCreateWithFlags(&kernelDone, cudaEventDisableTiming) != cudaSuccess)
     {
-        launchStatus = cuStreamSynchronize
-        (
-            reinterpret_cast<CUstream>(ctx.stream())
-        );
-
-        if (launchStatus != CUDA_SUCCESS)
-        {
-            error = "cuStreamSynchronize failed: "
-              + cudaDriverErrorString(launchStatus);
-            return tmp<fvMatrix<Type>>();
-        }
+        error = "cudaEventCreate(kernelDone) failed";
+        return tmp<fvMatrix<Type>>();
     }
+
+    if (cudaEventRecord(kernelDone, ctx.computeStream()) != cudaSuccess)
+    {
+        cudaEventDestroy(kernelDone);
+        error = "cudaEventRecord(kernelDone) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    if (cudaStreamWaitEvent(ctx.transferStream(), kernelDone, 0) != cudaSuccess)
+    {
+        cudaEventDestroy(kernelDone);
+        error = "cudaStreamWaitEvent(kernelDone) failed";
+        return tmp<fvMatrix<Type>>();
+    }
+
+    bool copyOk = true;
 
     if
     (
-        cudaMemcpy
+        cudaMemcpyAsync
         (
             diag.begin(),
             diagPtr,
             diagBytes,
-            cudaMemcpyDeviceToHost
+            cudaMemcpyDeviceToHost,
+            ctx.transferStream()
         ) != cudaSuccess
     )
     {
-        error = "cudaMemcpy(diag device->host) failed";
-        return tmp<fvMatrix<Type>>();
+        error = "cudaMemcpyAsync(diag device->host) failed";
+        copyOk = false;
     }
 
     scalar* sourceHost = reinterpret_cast<scalar*>(source.begin());
+    if (copyOk)
+    {
+        if
+        (
+            cudaMemcpyAsync
+            (
+                sourceHost,
+                sourcePtr,
+                sourceBytes,
+                cudaMemcpyDeviceToHost,
+                ctx.transferStream()
+            ) != cudaSuccess
+        )
+        {
+            error = "cudaMemcpyAsync(source device->host) failed";
+            copyOk = false;
+        }
+    }
+
+    cudaEventDestroy(kernelDone);
+
+    if (!copyOk)
+    {
+        return tmp<fvMatrix<Type>>();
+    }
+
     if
     (
-        cudaMemcpy
-        (
-            sourceHost,
-            sourcePtr,
-            sourceBytes,
-            cudaMemcpyDeviceToHost
-        ) != cudaSuccess
+        cudaStreamSynchronize(ctx.transferStream()) != cudaSuccess
     )
     {
-        error = "cudaMemcpy(source device->host) failed";
+        error = "cudaStreamSynchronize(ddt copies) failed";
         return tmp<fvMatrix<Type>>();
     }
 
@@ -930,6 +703,8 @@ tmp<fvMatrix<Type>> laplacian
 
     const label nFaces = mesh.nInternalFaces();
 
+    bool copiedUpper = false;
+
     if (nFaces)
     {
         DeviceBuffer gammaDev;
@@ -950,39 +725,42 @@ tmp<fvMatrix<Type>> laplacian
 
         if
         (
-            cudaMemcpy
+            cudaMemcpyAsync
             (
                 gammaDev.get(),
                 gammaMagSf.primitiveField().begin(),
                 bytes,
-                cudaMemcpyHostToDevice
+                cudaMemcpyHostToDevice,
+                ctx.transferStream()
             ) != cudaSuccess
         )
         {
-            error = "cudaMemcpy(gammaMagSf host->device) failed";
+            error = "cudaMemcpyAsync(gammaMagSf host->device) failed";
             return tmp<fvMatrix<Type>>();
         }
 
         if
         (
-            cudaMemcpy
+            cudaMemcpyAsync
             (
                 deltaDev.get(),
                 deltaCoeffsRef.primitiveField().begin(),
                 bytes,
-                cudaMemcpyHostToDevice
+                cudaMemcpyHostToDevice,
+                ctx.transferStream()
             ) != cudaSuccess
         )
         {
-            error = "cudaMemcpy(deltaCoeffs host->device) failed";
+            error = "cudaMemcpyAsync(deltaCoeffs host->device) failed";
             return tmp<fvMatrix<Type>>();
         }
 
-        CUmodule module = nullptr;
-        CUfunction function = nullptr;
-
-        if (!compileGaussLaplacianKernel(module, function, error))
+        if
+        (
+            cudaStreamSynchronize(ctx.transferStream()) != cudaSuccess
+        )
         {
+            error = "cudaStreamSynchronize(Laplacian coeff copies) failed";
             return tmp<fvMatrix<Type>>();
         }
 
@@ -993,74 +771,113 @@ tmp<fvMatrix<Type>> laplacian
         int faces = static_cast<int>(nFaces);
         void* args[] = { &upperPtr, &gammaPtr, &deltaPtr, &faces };
 
-        cudaEvent_t startEvent = nullptr;
-        cudaEvent_t stopEvent = nullptr;
+        static const word kernelKey("assembleGaussLaplacian");
 
-        if (stats)
+        CompiledKernel kernel;
+        if
+        (
+            !KernelCache::instance().getOrCompile
+            (
+                ctx,
+                kernelKey,
+                gaussLaplacianSource(),
+                {},
+                "assembleGaussLaplacian",
+                kernel,
+                error
+            )
+        )
         {
-            cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-            cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-            cudaEventRecord(startEvent, ctx.stream());
+            return tmp<fvMatrix<Type>>();
         }
 
-        CUresult launchStatus = cuLaunchKernel
-        (
-            function,
-            (faces + 255)/256, 1, 1,
-            256, 1, 1,
-            0,
-            reinterpret_cast<CUstream>(ctx.stream()),
-            args,
-            nullptr
-        );
+        scalar elapsedMs = 0;
 
-        if (launchStatus != CUDA_SUCCESS)
+        if
+        (
+            !GraphLaunchCache::instance().launch
+            (
+                ctx,
+                kernelKey,
+                kernel,
+                StreamCategory::compute,
+                dim3((faces + 255)/256, 1, 1),
+                dim3(256, 1, 1),
+                args,
+                sizeof(args)/sizeof(args[0]),
+                0,
+                error,
+                stats != nullptr,
+                elapsedMs
+            )
+        )
         {
-            error = "cuLaunchKernel(assembleGaussLaplacian) failed: "
-              + cudaDriverErrorString(launchStatus);
             return tmp<fvMatrix<Type>>();
         }
 
         if (stats)
         {
-            cudaEventRecord(stopEvent, ctx.stream());
-            cudaEventSynchronize(stopEvent);
-
-            float ms = 0.0f;
-            cudaEventElapsedTime(&ms, startEvent, stopEvent);
-            stats->gpuMilliseconds = static_cast<scalar>(ms);
-            cudaEventDestroy(startEvent);
-            cudaEventDestroy(stopEvent);
+            stats->gpuMilliseconds = elapsedMs;
         }
-        else
+
+        cudaEvent_t kernelDone = nullptr;
+        if (cudaEventCreateWithFlags(&kernelDone, cudaEventDisableTiming) != cudaSuccess)
         {
-            launchStatus = cuStreamSynchronize
-            (
-                reinterpret_cast<CUstream>(ctx.stream())
-            );
-
-            if (launchStatus != CUDA_SUCCESS)
-            {
-                error = "cuStreamSynchronize failed: "
-                  + cudaDriverErrorString(launchStatus);
-                return tmp<fvMatrix<Type>>();
-            }
+            error = "cudaEventCreate(laplacian kernel) failed";
+            return tmp<fvMatrix<Type>>();
         }
+
+        if (cudaEventRecord(kernelDone, ctx.computeStream()) != cudaSuccess)
+        {
+            cudaEventDestroy(kernelDone);
+            error = "cudaEventRecord(laplacian kernel) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if (cudaStreamWaitEvent(ctx.transferStream(), kernelDone, 0) != cudaSuccess)
+        {
+            cudaEventDestroy(kernelDone);
+            error = "cudaStreamWaitEvent(laplacian kernel) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        bool copyOk = true;
 
         if
         (
-            cudaMemcpy
+            cudaMemcpyAsync
             (
                 upper.begin(),
                 upperDev.get(),
                 bytes,
-                cudaMemcpyDeviceToHost
+                cudaMemcpyDeviceToHost,
+                ctx.transferStream()
             ) != cudaSuccess
         )
         {
-            error = "cudaMemcpy(upper device->host) failed";
+            error = "cudaMemcpyAsync(upper device->host) failed";
+            copyOk = false;
+        }
+
+        if (!copyOk)
+        {
+            cudaEventDestroy(kernelDone);
             return tmp<fvMatrix<Type>>();
         }
+
+        if
+        (
+            cudaStreamSynchronize(ctx.transferStream()) != cudaSuccess
+        )
+        {
+            cudaEventDestroy(kernelDone);
+            error = "cudaStreamSynchronize(laplacian copies) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        cudaEventDestroy(kernelDone);
+
+        copiedUpper = true;
     }
     else if (stats)
     {
@@ -1119,6 +936,25 @@ tmp<fvMatrix<Type>> laplacian
     if (mesh.schemes().fluxRequired(vf.name()))
     {
         mat.faceFluxCorrectionPtr() = tFaceFluxCorrection.ptr();
+    }
+
+    if (stats)
+    {
+        tmp<fvMatrix<Type>> tCpuLapCheck = Foam::fvm::laplacian(gamma, vf);
+        const scalarField& gpuSrc = mat.source();
+        const scalarField& cpuSrc = tCpuLapCheck().source();
+        scalar diffSq = 0.0;
+        scalar refSq = 0.0;
+        forAll(gpuSrc, celli)
+        {
+            const scalar diff = gpuSrc[celli] - cpuSrc[celli];
+            const scalar w = mesh.V()[celli];
+            diffSq += w*diff*diff;
+            refSq += w*cpuSrc[celli]*cpuSrc[celli];
+        }
+        refSq = max(refSq, VSMALL);
+        Info<< "GPU laplacian source mismatch (pre-solve): "
+            << Foam::sqrt(diffSq/refSq) << nl;
     }
 
     usedGpu = true;
@@ -1190,6 +1026,8 @@ tmp<fvMatrix<Type>> div
 
     const label nFaces = mesh.nInternalFaces();
 
+    bool copiedCoeffs = false;
+
     if (nFaces)
     {
         DeviceField<surfaceScalarField>& fluxDev =
@@ -1212,14 +1050,6 @@ tmp<fvMatrix<Type>> div
             return tmp<fvMatrix<Type>>();
         }
 
-        CUmodule module = nullptr;
-        CUfunction function = nullptr;
-
-        if (!compileGaussDivKernel(module, function, error))
-        {
-            return tmp<fvMatrix<Type>>();
-        }
-
         double* lowerPtr = reinterpret_cast<double*>(lowerDev.get());
         double* upperPtr = reinterpret_cast<double*>(upperDev.get());
         double* fluxPtr = reinterpret_cast<double*>(fluxDev.devicePointer());
@@ -1233,89 +1063,133 @@ tmp<fvMatrix<Type>> div
         int faces = static_cast<int>(nFaces);
         void* args[] = { &lowerPtr, &upperPtr, &fluxPtr, &faces };
 
-        cudaEvent_t startEvent = nullptr;
-        cudaEvent_t stopEvent = nullptr;
+        static const word kernelKey("assembleGaussDiv");
 
-        if (stats)
+        CompiledKernel kernel;
+        if
+        (
+            !KernelCache::instance().getOrCompile
+            (
+                ctx,
+                kernelKey,
+                gaussDivSource(),
+                {},
+                "assembleGaussDiv",
+                kernel,
+                error
+            )
+        )
         {
-            cudaEventCreateWithFlags(&startEvent, cudaEventDefault);
-            cudaEventCreateWithFlags(&stopEvent, cudaEventDefault);
-            cudaEventRecord(startEvent, ctx.stream());
+            return tmp<fvMatrix<Type>>();
         }
 
-        CUresult launchStatus = cuLaunchKernel
-        (
-            function,
-            (faces + 255)/256, 1, 1,
-            256, 1, 1,
-            0,
-            reinterpret_cast<CUstream>(ctx.stream()),
-            args,
-            nullptr
-        );
+        scalar elapsedMs = 0;
 
-        if (launchStatus != CUDA_SUCCESS)
+        if
+        (
+            !GraphLaunchCache::instance().launch
+            (
+                ctx,
+                kernelKey,
+                kernel,
+                StreamCategory::compute,
+                dim3((faces + 255)/256, 1, 1),
+                dim3(256, 1, 1),
+                args,
+                sizeof(args)/sizeof(args[0]),
+                0,
+                error,
+                stats != nullptr,
+                elapsedMs
+            )
+        )
         {
-            error = "cuLaunchKernel(assembleGaussDiv) failed: "
-              + cudaDriverErrorString(launchStatus);
             return tmp<fvMatrix<Type>>();
         }
 
         if (stats)
         {
-            cudaEventRecord(stopEvent, ctx.stream());
-            cudaEventSynchronize(stopEvent);
-
-            float ms = 0.0f;
-            cudaEventElapsedTime(&ms, startEvent, stopEvent);
-            stats->gpuMilliseconds = static_cast<scalar>(ms);
-            cudaEventDestroy(startEvent);
-            cudaEventDestroy(stopEvent);
+            stats->gpuMilliseconds = elapsedMs;
         }
-        else
+
+        cudaEvent_t kernelDone = nullptr;
+        if (cudaEventCreateWithFlags(&kernelDone, cudaEventDisableTiming) != cudaSuccess)
         {
-            launchStatus = cuStreamSynchronize
-            (
-                reinterpret_cast<CUstream>(ctx.stream())
-            );
-
-            if (launchStatus != CUDA_SUCCESS)
-            {
-                error = "cuStreamSynchronize failed: "
-                  + cudaDriverErrorString(launchStatus);
-                return tmp<fvMatrix<Type>>();
-            }
+            error = "cudaEventCreate(div kernel) failed";
+            return tmp<fvMatrix<Type>>();
         }
+
+        if (cudaEventRecord(kernelDone, ctx.computeStream()) != cudaSuccess)
+        {
+            cudaEventDestroy(kernelDone);
+            error = "cudaEventRecord(div kernel) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        if (cudaStreamWaitEvent(ctx.transferStream(), kernelDone, 0) != cudaSuccess)
+        {
+            cudaEventDestroy(kernelDone);
+            error = "cudaStreamWaitEvent(div kernel) failed";
+            return tmp<fvMatrix<Type>>();
+        }
+
+        const std::size_t coeffBytes = sizeof(scalar)*nFaces;
+        bool copyOk = true;
 
         if
         (
-            cudaMemcpy
+            cudaMemcpyAsync
             (
                 lower.begin(),
                 lowerDev.get(),
-                sizeof(scalar)*nFaces,
-                cudaMemcpyDeviceToHost
+                coeffBytes,
+                cudaMemcpyDeviceToHost,
+                ctx.transferStream()
             ) != cudaSuccess
         )
         {
-            error = "cudaMemcpy(lower device->host) failed";
+            error = "cudaMemcpyAsync(lower device->host) failed";
+            copyOk = false;
+        }
+
+        if (copyOk)
+        {
+            if
+            (
+                cudaMemcpyAsync
+                (
+                    upper.begin(),
+                    upperDev.get(),
+                    coeffBytes,
+                    cudaMemcpyDeviceToHost,
+                    ctx.transferStream()
+                ) != cudaSuccess
+            )
+            {
+                error = "cudaMemcpyAsync(upper device->host) failed";
+                copyOk = false;
+            }
+        }
+
+        if (!copyOk)
+        {
+            cudaEventDestroy(kernelDone);
             return tmp<fvMatrix<Type>>();
         }
 
         if
         (
-            cudaMemcpy
-            (
-                upper.begin(),
-                upperDev.get(),
-                sizeof(scalar)*nFaces,
-                cudaMemcpyDeviceToHost
-            ) != cudaSuccess
+            cudaStreamSynchronize(ctx.transferStream()) != cudaSuccess
         )
         {
-            error = "cudaMemcpy(upper device->host) failed";
+            cudaEventDestroy(kernelDone);
+            error = "cudaStreamSynchronize(div copies) failed";
             return tmp<fvMatrix<Type>>();
         }
+
+        cudaEventDestroy(kernelDone);
+
+        copiedCoeffs = true;
     }
     else if (stats)
     {

--- a/src/gpuInfrastructure/FvOperators/FvOperators.H
+++ b/src/gpuInfrastructure/FvOperators/FvOperators.H
@@ -1,0 +1,65 @@
+#ifndef Foam_gpu_FvOperators_H
+#define Foam_gpu_FvOperators_H
+
+#include "DeviceField.H"
+#include "FieldOps.H"
+#include "fvMatrix.H"
+#include "volFieldsFwd.H"
+#include "tmp.H"
+
+namespace Foam
+{
+namespace gpu
+{
+namespace fvm
+{
+
+//- Assemble the Euler fvm::ddt operator on the GPU for volume fields.
+//  Currently supports the Euler ddt scheme on stationary meshes. Returns an
+//  empty tmp<> and sets usedGpu=false when falling back to the CPU path.
+template<class Type>
+tmp<fvMatrix<Type>> ddt
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
+//- Assemble the convection operator fvm::div(faceFlux, vf) on the GPU.
+//  Supports Gauss-based schemes (linearUpwind/upwind) with CPU corrections for
+//  boundary terms. Returns empty tmp<> with usedGpu=false on fallback.
+template<class Type>
+tmp<fvMatrix<Type>> div
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    const surfaceScalarField& faceFlux,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
+//- Assemble the laplacian operator fvm::laplacian(gamma, vf) on the GPU.
+//  Currently targets scalar diffusivity fields and Gauss schemes. Returns an
+//  empty tmp<> with usedGpu=false on fallback.
+template<class Type>
+tmp<fvMatrix<Type>> laplacian
+(
+    Context& ctx,
+    FieldRegistry& registry,
+    const GeometricField<scalar, fvPatchField, volMesh>& gamma,
+    GeometricField<Type, fvPatchField, volMesh>& vf,
+    bool& usedGpu,
+    word& error,
+    OperationStats* stats = nullptr
+);
+
+} // namespace fvm
+} // namespace gpu
+} // namespace Foam
+
+#endif

--- a/src/gpuInfrastructure/GpuContext/GpuContext.C
+++ b/src/gpuInfrastructure/GpuContext/GpuContext.C
@@ -1,0 +1,147 @@
+#include "GpuContext.H"
+#include "error.H"
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda_runtime_api.h>
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+Context::Context()
+#ifdef FOAM_USE_CUDA
+:
+    initialised_(false),
+    deviceId_(-1),
+    stream_(nullptr)
+#endif
+{}
+
+
+Context::~Context()
+{
+    reset();
+}
+
+
+bool Context::initialise(int deviceId, word& errMessage)
+{
+#ifdef FOAM_USE_CUDA
+    if (initialised_)
+    {
+        return true;
+    }
+
+    int count = 0;
+    cudaError_t status = ::cudaGetDeviceCount(&count);
+
+    if (status != cudaSuccess || count == 0)
+    {
+        errMessage = "cudaGetDeviceCount failed";
+        return false;
+    }
+
+    if (deviceId < 0 || deviceId >= count)
+    {
+        deviceId = 0;
+    }
+
+    status = ::cudaSetDevice(deviceId);
+    if (status != cudaSuccess)
+    {
+        errMessage = "cudaSetDevice failed";
+        return false;
+    }
+
+    status = ::cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
+    if (status != cudaSuccess)
+    {
+        errMessage = "cudaStreamCreateWithFlags failed";
+        stream_ = nullptr;
+        return false;
+    }
+
+    initialised_ = true;
+    deviceId_ = deviceId;
+    errMessage.clear();
+    return true;
+#else
+    (void)deviceId;
+    errMessage = "CUDA support not available in this build";
+    return false;
+#endif
+}
+
+
+void Context::reset()
+{
+#ifdef FOAM_USE_CUDA
+    if (initialised_)
+    {
+        if (stream_)
+        {
+            ::cudaStreamDestroy(stream_);
+            stream_ = nullptr;
+        }
+        initialised_ = false;
+        deviceId_ = -1;
+    }
+#endif
+}
+
+
+bool Context::ready() const
+{
+#ifdef FOAM_USE_CUDA
+    return initialised_;
+#else
+    return false;
+#endif
+}
+
+
+int Context::deviceId() const
+{
+#ifdef FOAM_USE_CUDA
+    return deviceId_;
+#else
+    return -1;
+#endif
+}
+
+
+cudaStream_t Context::stream() const
+{
+#ifdef FOAM_USE_CUDA
+    return stream_;
+#else
+    return nullptr;
+#endif
+}
+
+
+bool available()
+{
+    return globalContext().ready();
+}
+
+
+Context& globalContext()
+{
+    static Context ctx;
+    if (!ctx.ready())
+    {
+        word err;
+        ctx.initialise(0, err);
+        if (!err.empty())
+        {
+            WarningIn("Foam::gpu::globalContext") << err << nl;
+        }
+    }
+    return ctx;
+}
+
+} // namespace gpu
+} // namespace Foam

--- a/src/gpuInfrastructure/GpuContext/GpuContext.C
+++ b/src/gpuInfrastructure/GpuContext/GpuContext.C
@@ -15,7 +15,11 @@ Context::Context()
 :
     initialised_(false),
     deviceId_(-1),
-    stream_(nullptr)
+    computeStream_(nullptr),
+    transferStream_(nullptr),
+    auxStream_(nullptr),
+    deviceProps_(),
+    archTag_()
 #endif
 {}
 
@@ -55,11 +59,48 @@ bool Context::initialise(int deviceId, word& errMessage)
         return false;
     }
 
-    status = ::cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
+    status = ::cudaGetDeviceProperties(&deviceProps_, deviceId);
     if (status != cudaSuccess)
     {
-        errMessage = "cudaStreamCreateWithFlags failed";
-        stream_ = nullptr;
+        errMessage = "cudaGetDeviceProperties failed";
+        return false;
+    }
+
+    archTag_ =
+        word
+        (
+            "compute_"
+          + Foam::name(deviceProps_.major)
+          + Foam::name(deviceProps_.minor)
+        );
+
+    status = ::cudaStreamCreateWithFlags(&computeStream_, cudaStreamNonBlocking);
+    if (status != cudaSuccess)
+    {
+        errMessage = "cudaStreamCreateWithFlags (compute) failed";
+        computeStream_ = nullptr;
+        return false;
+    }
+
+    status = ::cudaStreamCreateWithFlags(&transferStream_, cudaStreamNonBlocking);
+    if (status != cudaSuccess)
+    {
+        errMessage = "cudaStreamCreateWithFlags (transfer) failed";
+        ::cudaStreamDestroy(computeStream_);
+        computeStream_ = nullptr;
+        transferStream_ = nullptr;
+        return false;
+    }
+
+    status = ::cudaStreamCreateWithFlags(&auxStream_, cudaStreamNonBlocking);
+    if (status != cudaSuccess)
+    {
+        errMessage = "cudaStreamCreateWithFlags (aux) failed";
+        ::cudaStreamDestroy(computeStream_);
+        ::cudaStreamDestroy(transferStream_);
+        computeStream_ = nullptr;
+        transferStream_ = nullptr;
+        auxStream_ = nullptr;
         return false;
     }
 
@@ -80,13 +121,25 @@ void Context::reset()
 #ifdef FOAM_USE_CUDA
     if (initialised_)
     {
-        if (stream_)
+        if (computeStream_)
         {
-            ::cudaStreamDestroy(stream_);
-            stream_ = nullptr;
+            ::cudaStreamDestroy(computeStream_);
+            computeStream_ = nullptr;
+        }
+        if (transferStream_)
+        {
+            ::cudaStreamDestroy(transferStream_);
+            transferStream_ = nullptr;
+        }
+        if (auxStream_)
+        {
+            ::cudaStreamDestroy(auxStream_);
+            auxStream_ = nullptr;
         }
         initialised_ = false;
         deviceId_ = -1;
+        archTag_.clear();
+        deviceProps_ = cudaDeviceProp{};
     }
 #endif
 }
@@ -115,7 +168,79 @@ int Context::deviceId() const
 cudaStream_t Context::stream() const
 {
 #ifdef FOAM_USE_CUDA
-    return stream_;
+    return computeStream_;
+#else
+    return nullptr;
+#endif
+}
+
+
+cudaStream_t Context::computeStream() const
+{
+#ifdef FOAM_USE_CUDA
+    return computeStream_;
+#else
+    return nullptr;
+#endif
+}
+
+
+cudaStream_t Context::transferStream() const
+{
+#ifdef FOAM_USE_CUDA
+    return transferStream_;
+#else
+    return nullptr;
+#endif
+}
+
+
+cudaStream_t Context::auxStream() const
+{
+#ifdef FOAM_USE_CUDA
+    return auxStream_;
+#else
+    return nullptr;
+#endif
+}
+
+
+const cudaDeviceProp& Context::deviceProperties() const
+{
+#ifdef FOAM_USE_CUDA
+    return deviceProps_;
+#else
+    static cudaDeviceProp dummy{};
+    return dummy;
+#endif
+}
+
+
+const word& Context::architectureTag() const
+{
+#ifdef FOAM_USE_CUDA
+    return archTag_;
+#else
+    static const word empty;
+    return empty;
+#endif
+}
+
+
+int Context::capabilityMajor() const
+{
+#ifdef FOAM_USE_CUDA
+    return initialised_ ? deviceProps_.major : -1;
+#else
+    return -1;
+#endif
+}
+
+
+int Context::capabilityMinor() const
+{
+#ifdef FOAM_USE_CUDA
+    return initialised_ ? deviceProps_.minor : -1;
 #else
     return nullptr;
 #endif

--- a/src/gpuInfrastructure/GpuContext/GpuContext.H
+++ b/src/gpuInfrastructure/GpuContext/GpuContext.H
@@ -1,0 +1,62 @@
+#ifndef Foam_gpu_GpuContext_H
+#define Foam_gpu_GpuContext_H
+
+#include "Switch.H"
+#include "word.H"
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda_runtime.h>
+#else
+    typedef void* cudaStream_t;
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+class Context
+{
+#ifdef FOAM_USE_CUDA
+    bool initialised_;
+    int deviceId_;
+    cudaStream_t stream_;
+#endif
+
+public:
+
+    Context();
+    ~Context();
+
+    //- Disable copy
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
+
+    //- Initialise the context on the requested device.
+    //  Returns true on success and populates err on failure.
+    bool initialise(int deviceId, word& errMessage);
+
+    //- Destroy the context resources if initialised.
+    void reset();
+
+    //- True when the context owns a CUDA stream and device.
+    bool ready() const;
+
+    //- Return the active device id (or -1 if not initialised).
+    int deviceId() const;
+
+    //- Return the stream (nullptr if not initialised or CUDA disabled).
+    cudaStream_t stream() const;
+};
+
+//- Return true when CUDA support is enabled at compile time and the runtime
+//  initialisation succeeded.
+bool available();
+
+//- Obtain a global singleton context. The first call initialises it on device 0.
+Context& globalContext();
+
+} // namespace gpu
+} // namespace Foam
+
+#endif

--- a/src/gpuInfrastructure/GpuContext/GpuContext.H
+++ b/src/gpuInfrastructure/GpuContext/GpuContext.H
@@ -20,7 +20,11 @@ class Context
 #ifdef FOAM_USE_CUDA
     bool initialised_;
     int deviceId_;
-    cudaStream_t stream_;
+    cudaStream_t computeStream_;
+    cudaStream_t transferStream_;
+    cudaStream_t auxStream_;
+    cudaDeviceProp deviceProps_;
+    word archTag_;
 #endif
 
 public:
@@ -45,8 +49,29 @@ public:
     //- Return the active device id (or -1 if not initialised).
     int deviceId() const;
 
-    //- Return the stream (nullptr if not initialised or CUDA disabled).
+    //- Return the default compute stream (nullptr if not initialised or CUDA disabled).
     cudaStream_t stream() const;
+
+    //- Return the compute stream used for kernel launches.
+    cudaStream_t computeStream() const;
+
+    //- Stream dedicated to host<->device transfers.
+    cudaStream_t transferStream() const;
+
+    //- Auxiliary stream for optional concurrent kernels.
+    cudaStream_t auxStream() const;
+
+    //- Access cached device properties (undefined if not initialised).
+    const cudaDeviceProp& deviceProperties() const;
+
+    //- Architecture tag in the form compute_XY (empty if not initialised).
+    const word& architectureTag() const;
+
+    //- Major compute capability (returns -1 if not initialised).
+    int capabilityMajor() const;
+
+    //- Minor compute capability (returns -1 if not initialised).
+    int capabilityMinor() const;
 };
 
 //- Return true when CUDA support is enabled at compile time and the runtime

--- a/src/gpuInfrastructure/KernelCache/KernelCache.C
+++ b/src/gpuInfrastructure/KernelCache/KernelCache.C
@@ -1,0 +1,991 @@
+#include "KernelCache.H"
+#include "error.H"
+#include "OSspecific.H"
+#include "fileName.H"
+#include "SHA1.H"
+
+#include <array>
+#include <atomic>
+#include <cctype>
+#include <fstream>
+#include <functional>
+#include <mutex>
+#include <sstream>
+#include <utility>
+#include <unordered_map>
+#include <vector>
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda.h>
+    #include <cuda_runtime.h>
+    #include <cuda_runtime_api.h>
+#endif
+
+#if defined(FOAM_USE_CUDA)
+    #if CUDA_VERSION >= 10020
+        #define FOAM_GPU_CUDA_GRAPHS_AVAILABLE 1
+    #else
+        #define FOAM_GPU_CUDA_GRAPHS_AVAILABLE 0
+    #endif
+#else
+    #define FOAM_GPU_CUDA_GRAPHS_AVAILABLE 0
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+#ifdef FOAM_USE_CUDA
+namespace
+{
+
+struct KernelCacheEntry
+{
+    CUmodule module{nullptr};
+    CUfunction function{nullptr};
+    std::string ptx;
+};
+
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+struct GraphEntry
+{
+    CUgraph graph{nullptr};
+    CUgraphExec exec{nullptr};
+    CUgraphNode node{nullptr};
+    dim3 grid{};
+    dim3 block{};
+    std::size_t sharedMem{0};
+    CUfunction function{nullptr};
+    std::vector<std::array<unsigned char, sizeof(void*)>> paramBuffers;
+    std::vector<void*> initialParams;
+};
+#endif
+
+const char* ptxExtension()
+{
+    return ".ptx";
+}
+
+bool envSwitchOn(const std::string& value)
+{
+    if (value.empty())
+    {
+        return false;
+    }
+
+    std::string lowered(value);
+    for (char& c : lowered)
+    {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+
+    return lowered == "1"
+        || lowered == "true"
+        || lowered == "on"
+        || lowered == "yes";
+}
+
+Foam::fileName kernelCacheRoot()
+{
+    static const Foam::fileName dir = []
+    {
+        const std::string explicitDir = Foam::getEnv("FOAM_GPU_CACHE_DIR");
+        if (!explicitDir.empty())
+        {
+            Foam::fileName path(explicitDir);
+            Foam::mkDir(path);
+            return path;
+        }
+
+        const std::string xdg = Foam::getEnv("XDG_CACHE_HOME");
+        if (!xdg.empty())
+        {
+            Foam::fileName base(xdg);
+            Foam::mkDir(base);
+
+            Foam::fileName ofDir(base/"openfoam");
+            Foam::mkDir(ofDir);
+
+            Foam::fileName nvrtcDir(ofDir/"nvrtc");
+            Foam::mkDir(nvrtcDir);
+            return nvrtcDir;
+        }
+
+        Foam::fileName homeDir = Foam::home();
+        if (homeDir.empty())
+        {
+            return Foam::fileName::null;
+        }
+
+        Foam::fileName cacheDir(homeDir/".cache");
+        Foam::mkDir(cacheDir);
+
+        Foam::fileName ofDir(cacheDir/"openfoam");
+        Foam::mkDir(ofDir);
+
+        Foam::fileName nvrtcDir(ofDir/"nvrtc");
+        Foam::mkDir(nvrtcDir);
+        return nvrtcDir;
+    }();
+
+    return dir;
+}
+
+Foam::fileName cacheDirectoryForArch(const word& archTag)
+{
+    const Foam::fileName root = kernelCacheRoot();
+    if (root.empty())
+    {
+        return Foam::fileName::null;
+    }
+
+    Foam::fileName dir(root/Foam::fileName(archTag));
+    Foam::mkDir(dir);
+    return dir;
+}
+
+std::string makeKernelCacheKey
+(
+    const word& archTag,
+    const word& kernelKey,
+    const std::string& source,
+    const std::vector<std::string>& options
+)
+{
+    std::ostringstream os;
+    os << archTag << '|' << kernelKey << '|'
+       << std::hash<std::string>{}(source);
+    for (const auto& opt : options)
+    {
+        os << '|' << opt;
+    }
+    return os.str();
+}
+
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+std::string makeGraphCacheKey
+(
+    const word& archTag,
+    const word& kernelKey,
+    const dim3 grid,
+    const dim3 block,
+    const std::size_t sharedMem
+)
+{
+    std::ostringstream os;
+    os << archTag << '|' << kernelKey << '|'
+       << grid.x << ',' << grid.y << ',' << grid.z << '|'
+       << block.x << ',' << block.y << ',' << block.z << '|'
+       << sharedMem;
+    return os.str();
+}
+#endif
+
+std::string makeKernelDiskTag
+(
+    const word& lookupKey,
+    const std::string& source,
+    const std::vector<std::string>& options
+)
+{
+    Foam::SHA1 sha;
+    sha.append(lookupKey);
+    sha.append(source);
+
+    for (const auto& opt : options)
+    {
+        sha.append(opt);
+    }
+
+    sha.append(std::string("cuda:") + std::to_string(CUDA_VERSION));
+
+#ifdef NVRTC_VERSION
+    sha.append(std::string("nvrtc:") + std::to_string(NVRTC_VERSION));
+#endif
+
+    return sha.digest().str(false);
+}
+
+bool readFileContents(const Foam::fileName& path, std::string& data)
+{
+    std::ifstream in(path.c_str(), std::ios::binary);
+    if (!in)
+    {
+        return false;
+    }
+
+    in.seekg(0, std::ios::end);
+    const std::streampos end = in.tellg();
+    if (end < 0)
+    {
+        return false;
+    }
+
+    const std::size_t size = static_cast<std::size_t>(end);
+    data.resize(size);
+
+    in.seekg(0, std::ios::beg);
+    if (size)
+    {
+        in.read(&data[0], static_cast<std::streamsize>(size));
+    }
+
+    return in.good();
+}
+
+bool writeFileContents(const Foam::fileName& path, const std::string& data)
+{
+    std::ofstream out(path.c_str(), std::ios::binary | std::ios::trunc);
+    if (!out)
+    {
+        return false;
+    }
+
+    if (!data.empty())
+    {
+        out.write(data.data(), static_cast<std::streamsize>(data.size()));
+    }
+
+    return out.good();
+}
+
+bool loadModuleFromDisk
+(
+    const word& archTag,
+    const word& lookupKey,
+    const std::string& source,
+    const std::vector<std::string>& options,
+    const char* kernelName,
+    KernelCacheEntry& entry
+)
+{
+    const Foam::fileName dir = cacheDirectoryForArch(archTag);
+    if (dir.empty())
+    {
+        return false;
+    }
+
+    const std::string tag = makeKernelDiskTag(lookupKey, source, options);
+    const Foam::fileName ptxPath(dir/(tag + ptxExtension()));
+
+    if (!Foam::isFile(ptxPath))
+    {
+        return false;
+    }
+
+    std::string ptx;
+    if (!readFileContents(ptxPath, ptx))
+    {
+        return false;
+    }
+
+    CUresult status = cuModuleLoadData(&entry.module, ptx.c_str());
+    if (status != CUDA_SUCCESS)
+    {
+        entry.module = nullptr;
+        return false;
+    }
+
+    status = cuModuleGetFunction(&entry.function, entry.module, kernelName);
+    if (status != CUDA_SUCCESS)
+    {
+        cuModuleUnload(entry.module);
+        entry.module = nullptr;
+        entry.function = nullptr;
+        return false;
+    }
+
+    entry.ptx = std::move(ptx);
+    return true;
+}
+
+void storeModuleToDisk
+(
+    const word& archTag,
+    const word& lookupKey,
+    const std::string& source,
+    const std::vector<std::string>& options,
+    const std::string& ptx
+)
+{
+    if (ptx.empty())
+    {
+        return;
+    }
+
+    const Foam::fileName dir = cacheDirectoryForArch(archTag);
+    if (dir.empty())
+    {
+        return;
+    }
+
+    const std::string tag = makeKernelDiskTag(lookupKey, source, options);
+    const Foam::fileName ptxPath(dir/(tag + ptxExtension()));
+    writeFileContents(ptxPath, ptx);
+}
+
+std::unordered_map<std::string, KernelCacheEntry>& kernelCacheStorage()
+{
+    static std::unordered_map<std::string, KernelCacheEntry> cache;
+    return cache;
+}
+
+std::mutex& kernelCacheMutex()
+{
+    static std::mutex mutex;
+    return mutex;
+}
+
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+std::unordered_map<std::string, GraphEntry>& graphCacheStorage()
+{
+    static std::unordered_map<std::string, GraphEntry> cache;
+    return cache;
+}
+
+std::mutex& graphCacheMutex()
+{
+    static std::mutex mutex;
+    return mutex;
+}
+#endif
+
+bool defaultGraphsRequested()
+{
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    const std::string envValue = Foam::getEnv("FOAM_GPU_ENABLE_CUDA_GRAPHS");
+    if (!envValue.empty())
+    {
+        return envSwitchOn(envValue);
+    }
+#endif
+    return false;
+}
+
+std::atomic<bool>& graphsRequestedFlag()
+{
+    static std::atomic<bool> flag(defaultGraphsRequested());
+    return flag;
+}
+
+}
+#endif
+
+KernelCache& KernelCache::instance()
+{
+    static KernelCache cache;
+    return cache;
+}
+
+
+KernelCache::~KernelCache()
+{
+}
+
+
+bool KernelCache::getOrCompile
+(
+    Context& ctx,
+    const word& lookupKey,
+    const std::string& source,
+    const std::vector<std::string>& extraOptions,
+    const char* kernelName,
+    CompiledKernel& kernel,
+    word& error
+)
+{
+#ifdef FOAM_USE_CUDA
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return false;
+        }
+    }
+
+    const word& arch = ctx.architectureTag();
+    if (arch.empty())
+    {
+        error = "CUDA context architecture unknown";
+        return false;
+    }
+
+    std::vector<std::string> options;
+    options.reserve(2 + extraOptions.size());
+    options.emplace_back("--std=c++14");
+    options.emplace_back("--gpu-architecture=" + arch);
+    options.insert(options.end(), extraOptions.begin(), extraOptions.end());
+
+    const std::string cacheKey = makeKernelCacheKey(arch, lookupKey, source, options);
+
+    {
+        std::lock_guard<std::mutex> guard(kernelCacheMutex());
+        auto& cache = kernelCacheStorage();
+        const auto iter = cache.find(cacheKey);
+        if (iter != cache.end())
+        {
+            kernel.module = iter->second.module;
+            kernel.function = iter->second.function;
+            error.clear();
+            return kernel.module != nullptr && kernel.function != nullptr;
+        }
+    }
+
+    KernelCacheEntry cachedEntry;
+    if
+    (
+        loadModuleFromDisk
+        (
+            arch,
+            lookupKey,
+            source,
+            options,
+            kernelName,
+            cachedEntry
+        )
+    )
+    {
+        std::lock_guard<std::mutex> guard(kernelCacheMutex());
+        auto& cache = kernelCacheStorage();
+        const auto iter = cache.find(cacheKey);
+        if (iter != cache.end())
+        {
+            kernel.module = iter->second.module;
+            kernel.function = iter->second.function;
+        }
+        else
+        {
+            auto inserted = cache.emplace(cacheKey, std::move(cachedEntry));
+            if (!inserted.second)
+            {
+                if (cachedEntry.module)
+                {
+                    cuModuleUnload(cachedEntry.module);
+                    cachedEntry.module = nullptr;
+                }
+                kernel.module = inserted.first->second.module;
+                kernel.function = inserted.first->second.function;
+            }
+            else
+            {
+                kernel.module = inserted.first->second.module;
+                kernel.function = inserted.first->second.function;
+            }
+        }
+
+        error.clear();
+        return kernel.module != nullptr && kernel.function != nullptr;
+    }
+
+    nvrtcProgram prog;
+    nvrtcResult nvStatus = nvrtcCreateProgram
+    (
+        &prog,
+        source.c_str(),
+        (lookupKey + ".cu").c_str(),
+        0,
+        nullptr,
+        nullptr
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        error = "nvrtcCreateProgram failed: " + nvrtcErrorString(nvStatus);
+        return false;
+    }
+
+    std::vector<const char*> optionPtrs;
+    optionPtrs.reserve(options.size());
+    for (const auto& opt : options)
+    {
+        optionPtrs.push_back(opt.c_str());
+    }
+
+    nvStatus = nvrtcCompileProgram
+    (
+        prog,
+        static_cast<int>(optionPtrs.size()),
+        optionPtrs.data()
+    );
+
+    if (nvStatus != NVRTC_SUCCESS)
+    {
+        size_t logSize = 0;
+        nvrtcGetProgramLogSize(prog, &logSize);
+        std::string log(logSize, '\0');
+        if (logSize > 1)
+        {
+            nvrtcGetProgramLog(prog, &log[0]);
+        }
+
+        error = "nvrtcCompileProgram failed: " + nvrtcErrorString(nvStatus);
+        if (!log.empty())
+        {
+            error += " :: " + log;
+        }
+        nvrtcDestroyProgram(&prog);
+        return false;
+    }
+
+    size_t ptxSize = 0;
+    nvrtcGetPTXSize(prog, &ptxSize);
+    std::string ptx(ptxSize, '\0');
+    nvrtcGetPTX(prog, &ptx[0]);
+    nvrtcDestroyProgram(&prog);
+
+    KernelCacheEntry entry;
+    entry.ptx = ptx;
+
+    CUresult cuStatus = cuModuleLoadData(&entry.module, entry.ptx.c_str());
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleLoadData failed: " + cudaDriverErrorString(cuStatus);
+        return false;
+    }
+
+    cuStatus = cuModuleGetFunction(&entry.function, entry.module, kernelName);
+    if (cuStatus != CUDA_SUCCESS)
+    {
+        error = "cuModuleGetFunction failed: " + cudaDriverErrorString(cuStatus);
+        cuModuleUnload(entry.module);
+        return false;
+    }
+
+    storeModuleToDisk(arch, lookupKey, source, options, entry.ptx);
+
+    {
+        std::lock_guard<std::mutex> guard(kernelCacheMutex());
+        auto& cache = kernelCacheStorage();
+        auto inserted = cache.emplace(cacheKey, entry);
+        if (!inserted.second)
+        {
+            // Another thread inserted concurrently. Use stored copy.
+            cuModuleUnload(entry.module);
+            kernel.module = inserted.first->second.module;
+            kernel.function = inserted.first->second.function;
+        }
+        else
+        {
+            kernel.module = inserted.first->second.module;
+            kernel.function = inserted.first->second.function;
+        }
+    }
+
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)lookupKey;
+    (void)source;
+    (void)extraOptions;
+    (void)kernelName;
+    (void)kernel;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+
+void KernelCache::clear()
+{
+#ifdef FOAM_USE_CUDA
+    std::lock_guard<std::mutex> guard(kernelCacheMutex());
+    auto& cache = kernelCacheStorage();
+    for (auto& pair : cache)
+    {
+        if (pair.second.module)
+        {
+            cuModuleUnload(pair.second.module);
+            pair.second.module = nullptr;
+            pair.second.function = nullptr;
+        }
+    }
+    cache.clear();
+#endif
+}
+
+
+GraphLaunchCache& GraphLaunchCache::instance()
+{
+    static GraphLaunchCache cache;
+    return cache;
+}
+
+
+GraphLaunchCache::~GraphLaunchCache()
+{
+}
+
+
+bool GraphLaunchCache::launch
+(
+    Context& ctx,
+    const word& kernelKey,
+    const CompiledKernel& kernel,
+    StreamCategory streamCategory,
+#ifdef FOAM_USE_CUDA
+    dim3 grid,
+    dim3 block,
+#else
+    int grid,
+    int block,
+#endif
+    void** args,
+    std::size_t numArgs,
+    std::size_t sharedMemBytes,
+    word& error,
+    bool captureStats,
+    scalar& elapsedMs
+)
+{
+#ifdef FOAM_USE_CUDA
+    elapsedMs = 0;
+
+    if (!kernel.function)
+    {
+        error = "Kernel function handle is null";
+        return false;
+    }
+
+    if (!ctx.ready())
+    {
+        if (!ctx.initialise(0, error))
+        {
+            return false;
+        }
+    }
+
+    cudaStream_t stream =
+        streamCategory == StreamCategory::aux
+      ? ctx.auxStream()
+      : ctx.computeStream();
+
+    if (!stream)
+    {
+        error = "CUDA stream unavailable";
+        return false;
+    }
+
+    cudaEvent_t startEvent = nullptr;
+    cudaEvent_t stopEvent = nullptr;
+
+    if (captureStats)
+    {
+        if
+        (
+            cudaEventCreateWithFlags(&startEvent, cudaEventDefault) != cudaSuccess
+         || cudaEventCreateWithFlags(&stopEvent, cudaEventDefault) != cudaSuccess
+        )
+        {
+            if (startEvent)
+            {
+                cudaEventDestroy(startEvent);
+            }
+            error = "cudaEventCreate failed";
+            return false;
+        }
+        cudaEventRecord(startEvent, stream);
+    }
+
+    bool launched = false;
+
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    if (graphsEnabled())
+    {
+        const word& arch = ctx.architectureTag();
+        if (arch.empty())
+        {
+            if (captureStats)
+            {
+                cudaEventDestroy(startEvent);
+                cudaEventDestroy(stopEvent);
+            }
+            error = "CUDA context architecture unknown";
+            return false;
+        }
+
+        const std::string cacheKey =
+            makeGraphCacheKey(arch, kernelKey, grid, block, sharedMemBytes);
+
+        GraphEntry* entryPtr = nullptr;
+        {
+            std::lock_guard<std::mutex> guard(graphCacheMutex());
+            auto& cache = graphCacheStorage();
+            auto iter = cache.find(cacheKey);
+            if (iter == cache.end())
+            {
+                GraphEntry entry;
+                entry.grid = grid;
+                entry.block = block;
+                entry.sharedMem = sharedMemBytes;
+                entry.function = kernel.function;
+                entry.paramBuffers.resize(numArgs);
+                entry.initialParams.resize(numArgs);
+                for (std::size_t i = 0; i < numArgs; ++i)
+                {
+                    entry.initialParams[i] = entry.paramBuffers[i].data();
+                }
+
+                CUresult status = cuGraphCreate(&entry.graph, 0);
+                if (status != CUDA_SUCCESS)
+                {
+                    if (captureStats)
+                    {
+                        cudaEventDestroy(startEvent);
+                        cudaEventDestroy(stopEvent);
+                    }
+                    error = "cuGraphCreate failed: "
+                      + cudaDriverErrorString(status);
+                    return false;
+                }
+
+                CUDA_KERNEL_NODE_PARAMS params{};
+                params.func = kernel.function;
+                params.gridDimX = grid.x;
+                params.gridDimY = grid.y;
+                params.gridDimZ = grid.z;
+                params.blockDimX = block.x;
+                params.blockDimY = block.y;
+                params.blockDimZ = block.z;
+                params.sharedMemBytes = sharedMemBytes;
+                params.kernelParams = entry.initialParams.empty()
+                    ? nullptr
+                    : entry.initialParams.data();
+                params.extra = nullptr;
+
+                status = cuGraphAddKernelNode
+                (
+                    &entry.node,
+                    entry.graph,
+                    nullptr,
+                    0,
+                    &params
+                );
+
+                if (status != CUDA_SUCCESS)
+                {
+                    if (captureStats)
+                    {
+                        cudaEventDestroy(startEvent);
+                        cudaEventDestroy(stopEvent);
+                    }
+                    error = "cuGraphAddKernelNode failed: "
+                      + cudaDriverErrorString(status);
+                    cuGraphDestroy(entry.graph);
+                    return false;
+                }
+
+            #if CUDA_VERSION >= 11040
+                status = cuGraphInstantiate(&entry.exec, entry.graph, 0);
+            #else
+                status = cuGraphInstantiate
+                (
+                    &entry.exec,
+                    entry.graph,
+                    nullptr,
+                    nullptr,
+                    0
+                );
+            #endif
+
+                if (status != CUDA_SUCCESS)
+                {
+                    if (captureStats)
+                    {
+                        cudaEventDestroy(startEvent);
+                        cudaEventDestroy(stopEvent);
+                    }
+                    error = "cuGraphInstantiate failed: "
+                      + cudaDriverErrorString(status);
+                    cuGraphDestroy(entry.graph);
+                    return false;
+                }
+
+                auto inserted = cache.emplace(cacheKey, std::move(entry));
+                entryPtr = &inserted.first->second;
+            }
+            else
+            {
+                entryPtr = &iter->second;
+            }
+        }
+
+        CUDA_KERNEL_NODE_PARAMS params{};
+        params.func = kernel.function;
+        params.gridDimX = grid.x;
+        params.gridDimY = grid.y;
+        params.gridDimZ = grid.z;
+        params.blockDimX = block.x;
+        params.blockDimY = block.y;
+        params.blockDimZ = block.z;
+        params.sharedMemBytes = sharedMemBytes;
+        params.kernelParams = args;
+        params.extra = nullptr;
+
+        CUresult status =
+            cuGraphExecKernelNodeSetParams(entryPtr->exec, entryPtr->node, &params);
+
+        if (status != CUDA_SUCCESS)
+        {
+            if (captureStats)
+            {
+                cudaEventDestroy(startEvent);
+                cudaEventDestroy(stopEvent);
+            }
+            error = "cuGraphExecKernelNodeSetParams failed: "
+              + cudaDriverErrorString(status);
+            return false;
+        }
+
+        status = cuGraphLaunch(entryPtr->exec, reinterpret_cast<CUstream>(stream));
+        if (status != CUDA_SUCCESS)
+        {
+            if (captureStats)
+            {
+                cudaEventDestroy(startEvent);
+                cudaEventDestroy(stopEvent);
+            }
+            error = "cuGraphLaunch failed: " + cudaDriverErrorString(status);
+            return false;
+        }
+
+        launched = true;
+    }
+#endif
+
+    if (!launched)
+    {
+        CUresult status = cuLaunchKernel
+        (
+            kernel.function,
+            grid.x, grid.y, grid.z,
+            block.x, block.y, block.z,
+            static_cast<unsigned int>(sharedMemBytes),
+            reinterpret_cast<CUstream>(stream),
+            args,
+            nullptr
+        );
+
+        if (status != CUDA_SUCCESS)
+        {
+            if (captureStats)
+            {
+                cudaEventDestroy(startEvent);
+                cudaEventDestroy(stopEvent);
+            }
+            error = "cuLaunchKernel failed: " + cudaDriverErrorString(status);
+            return false;
+        }
+    }
+
+    if (captureStats)
+    {
+        cudaEventRecord(stopEvent, stream);
+        cudaEventSynchronize(stopEvent);
+
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, startEvent, stopEvent);
+        elapsedMs = static_cast<scalar>(ms);
+        cudaEventDestroy(startEvent);
+        cudaEventDestroy(stopEvent);
+    }
+    else
+    {
+        elapsedMs = 0;
+    }
+
+    error.clear();
+    return true;
+#else
+    (void)ctx;
+    (void)kernelKey;
+    (void)kernel;
+    (void)streamCategory;
+    (void)args;
+    (void)sharedMemBytes;
+    (void)captureStats;
+    (void)grid;
+    (void)block;
+    elapsedMs = 0;
+    error = "CUDA support not available";
+    return false;
+#endif
+}
+
+
+void GraphLaunchCache::clear()
+{
+#if defined(FOAM_USE_CUDA) && FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    std::lock_guard<std::mutex> guard(graphCacheMutex());
+    auto& cache = graphCacheStorage();
+    for (auto& pair : cache)
+    {
+        if (pair.second.exec)
+        {
+            cuGraphExecDestroy(pair.second.exec);
+            pair.second.exec = nullptr;
+        }
+        if (pair.second.graph)
+        {
+            cuGraphDestroy(pair.second.graph);
+            pair.second.graph = nullptr;
+        }
+        pair.second.node = nullptr;
+        pair.second.function = nullptr;
+    }
+    cache.clear();
+#endif
+}
+
+
+#ifdef FOAM_USE_CUDA
+bool graphsSupported()
+{
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    return true;
+#else
+    return false;
+#endif
+}
+
+void setCudaGraphsRequested(const bool enabled)
+{
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    graphsRequestedFlag().store(enabled, std::memory_order_relaxed);
+#else
+    (void)enabled;
+#endif
+}
+
+bool graphsEnabled()
+{
+#if FOAM_GPU_CUDA_GRAPHS_AVAILABLE
+    return graphsRequestedFlag().load(std::memory_order_relaxed);
+#else
+    return false;
+#endif
+}
+
+std::string nvrtcErrorString(const nvrtcResult code)
+{
+    return std::string(nvrtcGetErrorString(code))
+        + " (" + Foam::name(static_cast<int>(code)) + ')';
+}
+
+
+std::string cudaDriverErrorString(const CUresult code)
+{
+    const char* msg = nullptr;
+    cuGetErrorString(code, &msg);
+    if (msg)
+    {
+        return std::string(msg)
+            + " (" + Foam::name(static_cast<int>(code)) + ')';
+    }
+    return "cuda driver error (" + Foam::name(static_cast<int>(code)) + ')';
+}
+#endif
+
+} // namespace gpu
+} // namespace Foam

--- a/src/gpuInfrastructure/KernelCache/KernelCache.H
+++ b/src/gpuInfrastructure/KernelCache/KernelCache.H
@@ -1,0 +1,115 @@
+#ifndef Foam_gpu_KernelCache_H
+#define Foam_gpu_KernelCache_H
+
+#include "GpuContext.H"
+#include "scalar.H"
+#include "word.H"
+
+#include <string>
+#include <vector>
+
+#ifdef FOAM_USE_CUDA
+    #include <cuda.h>
+    #include <nvrtc.h>
+#else
+    typedef void* CUmodule;
+    typedef void* CUfunction;
+    typedef void* CUgraph;
+    typedef void* CUgraphExec;
+    typedef void* CUgraphNode;
+#endif
+
+namespace Foam
+{
+namespace gpu
+{
+
+enum class StreamCategory
+{
+    compute,
+    aux
+};
+
+struct CompiledKernel
+{
+#ifdef FOAM_USE_CUDA
+    CUmodule module{nullptr};
+    CUfunction function{nullptr};
+#else
+    CUmodule module{nullptr};
+    CUfunction function{nullptr};
+#endif
+};
+
+class KernelCache
+{
+public:
+    static KernelCache& instance();
+
+    bool getOrCompile
+    (
+        Context& ctx,
+        const word& lookupKey,
+        const std::string& source,
+        const std::vector<std::string>& extraOptions,
+        const char* kernelName,
+        CompiledKernel& kernel,
+        word& error
+    );
+
+    void clear();
+
+private:
+    KernelCache() = default;
+    ~KernelCache();
+    KernelCache(const KernelCache&) = delete;
+    KernelCache& operator=(const KernelCache&) = delete;
+};
+
+class GraphLaunchCache
+{
+public:
+    static GraphLaunchCache& instance();
+
+    bool launch
+    (
+        Context& ctx,
+        const word& kernelKey,
+        const CompiledKernel& kernel,
+        StreamCategory streamCategory,
+#ifdef FOAM_USE_CUDA
+        dim3 grid,
+        dim3 block,
+#else
+        int grid,
+        int block,
+#endif
+        void** args,
+        std::size_t numArgs,
+        std::size_t sharedMemBytes,
+        word& error,
+        bool captureStats,
+        scalar& elapsedMs
+    );
+
+    void clear();
+
+private:
+    GraphLaunchCache() = default;
+    ~GraphLaunchCache();
+    GraphLaunchCache(const GraphLaunchCache&) = delete;
+    GraphLaunchCache& operator=(const GraphLaunchCache&) = delete;
+};
+
+#ifdef FOAM_USE_CUDA
+bool graphsSupported();
+void setCudaGraphsRequested(bool enabled);
+bool graphsEnabled();
+std::string nvrtcErrorString(const nvrtcResult code);
+std::string cudaDriverErrorString(const CUresult code);
+#endif
+
+} // namespace gpu
+} // namespace Foam
+
+#endif

--- a/src/gpuInfrastructure/Make/files
+++ b/src/gpuInfrastructure/Make/files
@@ -2,5 +2,6 @@ GpuContext/GpuContext.C
 DeviceField/DeviceField.C
 FieldOps/FieldOps.C
 FvOperators/FvOperators.C
+KernelCache/KernelCache.C
 
 LIB = $(FOAM_USER_LIBBIN)/libgpuInfrastructure

--- a/src/gpuInfrastructure/Make/files
+++ b/src/gpuInfrastructure/Make/files
@@ -1,0 +1,5 @@
+GpuContext/GpuContext.C
+DeviceField/DeviceField.C
+FieldOps/FieldOps.C
+
+LIB = $(FOAM_USER_LIBBIN)/libgpuInfrastructure

--- a/src/gpuInfrastructure/Make/files
+++ b/src/gpuInfrastructure/Make/files
@@ -1,5 +1,6 @@
 GpuContext/GpuContext.C
 DeviceField/DeviceField.C
 FieldOps/FieldOps.C
+FvOperators/FvOperators.C
 
 LIB = $(FOAM_USER_LIBBIN)/libgpuInfrastructure

--- a/src/gpuInfrastructure/Make/options
+++ b/src/gpuInfrastructure/Make/options
@@ -1,6 +1,8 @@
 EXE_INC = \
     -I$(LIB_SRC)/OpenFOAM/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/gpuInfrastructure/FvOperators \
     -I/usr/local/cuda/include \
     -DFOAM_USE_CUDA
 

--- a/src/gpuInfrastructure/Make/options
+++ b/src/gpuInfrastructure/Make/options
@@ -3,6 +3,7 @@ EXE_INC = \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/gpuInfrastructure/FvOperators \
+    -I$(LIB_SRC)/gpuInfrastructure/KernelCache \
     -I/usr/local/cuda/include \
     -DFOAM_USE_CUDA
 

--- a/src/gpuInfrastructure/Make/options
+++ b/src/gpuInfrastructure/Make/options
@@ -1,0 +1,13 @@
+EXE_INC = \
+    -I$(LIB_SRC)/OpenFOAM/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I/usr/local/cuda/include \
+    -DFOAM_USE_CUDA
+
+LIB_LIBS = \
+    -lOpenFOAM \
+    -lfiniteVolume \
+    -L/usr/local/cuda/lib64 \
+    -lcudart \
+    -lcuda \
+    -lnvrtc

--- a/src/gpuInfrastructure/lnInclude/DeviceField.C
+++ b/src/gpuInfrastructure/lnInclude/DeviceField.C
@@ -1,0 +1,1 @@
+../DeviceField/DeviceField.C

--- a/src/gpuInfrastructure/lnInclude/DeviceField.H
+++ b/src/gpuInfrastructure/lnInclude/DeviceField.H
@@ -1,0 +1,1 @@
+../DeviceField/DeviceField.H

--- a/src/gpuInfrastructure/lnInclude/FieldOps.C
+++ b/src/gpuInfrastructure/lnInclude/FieldOps.C
@@ -1,0 +1,1 @@
+../FieldOps/FieldOps.C

--- a/src/gpuInfrastructure/lnInclude/FieldOps.H
+++ b/src/gpuInfrastructure/lnInclude/FieldOps.H
@@ -1,0 +1,1 @@
+../FieldOps/FieldOps.H

--- a/src/gpuInfrastructure/lnInclude/GpuContext.C
+++ b/src/gpuInfrastructure/lnInclude/GpuContext.C
@@ -1,0 +1,1 @@
+../GpuContext/GpuContext.C

--- a/src/gpuInfrastructure/lnInclude/GpuContext.H
+++ b/src/gpuInfrastructure/lnInclude/GpuContext.H
@@ -1,0 +1,1 @@
+../GpuContext/GpuContext.H


### PR DESCRIPTION
PR 标题
  GPU 压力求解器 Phase 1：安全回退、脚本加固、SGS/彩色/ILU0/IC0 预条件器与可选平衡化（含复合预条件器）；GPU 有限体积算子与湍流路径接入；修复压力校正通量一致性

  分支概览（feature/gpu-linear-solver）

  - 最终目标：在同等硬件与同一案例（pitzDaily）上，GPU 端到端时间优于 CPU（≈35 s 基线），同时保持数值正确与稳定（最终时刻 U 相对 L2 ≤ 1e-2）。
  - 当前定位（Phase 1）：在不改变默认 CPU 行为的前提下，完成“可用但保守”的 GPU 压力求解器集成；补齐安全回退、关键预条件器、观测与脚本看门狗；并将 PIMPLE 主线
    中“可并行/可脱耦”的有限体积算子与湍流更新迁移到 GPU，打牢后续性能编排与收敛优化基础。

  现状（里程碑与差距）

  - 正确性与安全性：默认保持 CPU；GPU 为显式开启项。GPU 路径故障/停滞时自动回退 CPU（PCG+DIC），脚本 10 分钟看门狗兜底；字段对比与残差轨迹/统计完备。
  - 功能覆盖：GPU ddt/div/laplacian 核心算子与 k–ε 湍流更新已接入（运行时可选）；GPU 压力求解器 cudaPCG 可选（含 SGS/彩色/ILU0/IC0/复合、对称对角平衡化、早停
    与详尽遥测）。
  - 性能与收敛：pitzDaily Parity（允许回退）通过；当前端到端 GPU 仍慢于 CPU（例如 CPU≈33.5 s vs GPU≈40.5 s），主要瓶颈在压力求解（迭代数偏高＋GPU 调度与数据往
    返开销）。要达成“GPU 优于 CPU”，需要进一步降低迭代与收敛成本，并扩大 GPU 常驻覆盖与编排优化。

  关键变更（按价值分组）

  - 有限体积算子 GPU 化（运行时选择）
      - ddt、div(phi,U)、laplacian(rAtU(),p) 的设备变体；保持边界/格式与 CPU 一致；PIMPLE/useGpuFieldOps 控制，失败时回退 CPU。
      - 计时与统计输出（OperationStats，汇总 CSV）用于定位开销与回退热点。
  - 湍流路径（k–ε）GPU 化（保持 CPU 等价）
      - 设备侧更新 k/epsilon/nut（边界更新与主机回退完备）；后续其他 RAS 模型可按相同模式接入，尽量减少 H↔D 往返。
  - 压力求解器 cudaPCG（可选）
      - 预条件器：SGS、彩色 Gauss–Seidel（NVRTC 实时编译＋按架构缓存）、ILU0、IC0（cuSPARSE），以及复合（colour+IC0）。
      - 稳定性与安全：对角规则化（绝对+相对阈值统一策略）、零主元检测（csrilu02/csric02）、收敛停滞早停（earlyAbortOnStall/stallWindow/stallRatioTol），失败即
        回退 CPU 并落盘遥测。
      - 可选对称对角平衡化（equilibrateMatrix）：A' = S A S, b' = S b, x' = S^{-1} x，求解后反缩放，提升条件数。
      - 迭代/残差轨迹与彩色平滑统计落盘（postProcessing/cudaPCG/*.csv）；可启用迭代统计与阶段时长统计。
      - 运行时选择与库装载：在 system/fvSolution 中设置 p 求解器为 cudaPCG，并在 system/controlDict 的 libs 中追加 libcudaPCG.so；不可用/禁用时自动回退 CPU。
  - 脚本与看门狗
      - Parity：run/scripts/run_gpu_parity.sh 自动拷贝教程案例、构网、分别以 CPU/GPU 运行并比对字段（默认容差可传入，如 1e-2），GPU 运行 10 分钟超时。
      - Benchmark：run/scripts/benchmark_gpu_speed.sh 统计 CPU/GPU ExecutionTime，收集 GPU 内核计时汇总与回退样本数。
      - 脚本保持“追加 libs、默认不强制 cudaPCG、超时兜底”，尽量不干扰用户已有设置。
  - 回退路径健壮化（防崩溃）
      - GPU→CPU 回退时，规范化预条件器名并移除 GPU 专参，避免 CPU 工厂识别失败。
      - 名称映射：sgs|symGaussSeidel|ic|ic0|dic|colour(ed)→DIC；fdic→FDIC；gamg→GAMG；保留 diagonal|none。
  - 通量一致性修复（GPU 压力校正器）
      - 修正 phi 边界更新中的误写（==→=），恢复边界/内部通量一致；位置：applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H:517。
      - 修复后 pitzDaily Parity（φ/U）均为 0 相对 L2，验证 GPU/CPU 等价。

  使用与关键开关

  - PIMPLE GPU 算子与日志
      - PIMPLE/useGpuFieldOps：启用 GPU ddt/div/laplacian
      - PIMPLE/logGpuFieldOps：落盘每步/每算子的计时与回退标签（CSV）
      - PIMPLE/forceCpuPressureCorrector：压力校正器强制使用 CPU 结果（研发与排障用）
  - 压力求解（在 fvSolution 的 solvers/p 下）
      - solver：cudaPCG（启用 GPU 压力）；否则保持 CPU 路径
      - preconditioner：composite | ic0 | ilu0 | colour | sgs | diagonal/none（GPU 路径下可选）
      - 规则化阈值：preconditionerDiagFloor, preconditionerDiagRelFloor
      - ILU/IC 规则化与数值增强：iluDiagAbsFloor, iluDiagRelFloor, iluNumericBoost{,Tol,Val}
      - 复合参数：compositeColourSweeps（默认 2）
      - 对称平衡化：equilibrateMatrix {true|false}
      - 稳定/观测：earlyAbortOnStall {true|false}, stallWindow, stallRatioTol, logResidualTrajectory{,File}, logIterationStats
      - 编排探索：useCudaGraph {true|false}, cudaGraphWarmup，usePipelinedCG {true|false}
  - 控制字典与库
      - system/controlDict 追加 libs ("libcudaPCG.so");（脚本为追加模式，不覆盖用户已有条目）

  验证与当前结果（pitzDaily，0→0.3 s）

  - Parity（允许回退，容差 1e-2）：通过；phi/U 相对 L2 = 0；GPU/CPU 字段一致，修复后的边界通量一致性已生效。
  - Benchmark（不强制 GPU 压力）：示例 CPU≈33.5 s vs GPU≈40.5 s（≈0.83×）；GPU 慢的主因是压力求解收敛效率与调度/拷贝开销。
  - 强制全 GPU 压力（关闭停滞保护，用脚本看门狗兜底）：
      - 彩色：可收敛但迭代偏高（数百至 ~800）
      - IC0/ILU0：在对角规则化、数值增强与平衡化后，许多步仍达 1000；个别步降至 300–700，仍显著高于 CPU DIC（~200）
      - 复合（colour+IC0）：较单独 IC/ILU 更稳健，部分时间步 260–545，但整体仍偏高

  对“最终目标”的路线图（Phase 2+，建议延续分支推进）

  - 收敛效率
      - 复合策略增强：自适应增加彩色平滑步数；IC0 失败/非 SPD 条件串联 ILU0；无法稳定时退回对角；自动策略以减少人工调参
      - 条件性 GPU PBiCGStab：检测非 SPD/IC0 零主元频发时切换，保持“全 GPU”
      - 单层粗化校正（coarse correction）：与彩色/IC0/ILU0 组合，显著压缩迭代数
  - 性能编排与常驻
      - 完整 PIMPLE 回路 CUDA Graph 捕获与复用；多流重叠归约/传输；NVRTC 编译缓存按算力维度复用；最大化场数据常驻以减少 launch/拷贝
  - 覆盖面与多 GPU
      - 常用边界条件与 fvModels/fvConstraints 的 GPU 覆盖，减少强制回退
      - 逐步引入 CUDA-aware MPI（多 GPU），重叠交换/计算
  - 指标与 CI
      - 自动化跑 pitzDaily、字段对比与时序趋势；趋势回归与报警，确保“正确性不回退、性能稳提升”
  - 部署门槛
      - 本镜像构建通过＋pitzDaily GPU 试跑成功＋对比 CPU 参考满足阈值（最终 Ux 相对 L2 ≤ 1e-2）＋端到端时间优于 CPU 后，才申请复制到 /opt/openfoam10（最小变
        更，提前审批）

  构建与验证指引

  - 环境：. etc/bashrc（设置 WM_PROJECT_DIR 等）
  - 定点构建：
      - wmake libso src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG
      - wmake applications/solvers/incompressible/pimpleFoamGPU
  - 全量构建：./Allwmake（必要时 wclean all && ./Allwmake）
  - Parity：run/scripts/run_gpu_parity.sh pitzDaily _ 1e-2
  - Benchmark：run/scripts/benchmark_gpu_speed.sh pitzDaily_bench
  - 注意：*/lnInclude/、run/* 为构建/临时产物，不纳入版本控制

  主要涉及文件（审阅索引）

  - 压力求解器与导出：src/OpenFOAM/matrices/lduMatrix/solvers/cudaPCG/{cudaPCG.{C,H}, CsrExport.{C,H}, Make/*}
  - GPU 算子与基础设施：src/gpuInfrastructure/**（FieldOps/FvOperators、KernelCache 等）
  - pimpleFoamGPU 入口与方程：applications/solvers/incompressible/pimpleFoamGPU/{pimpleFoamGPU.C, UEqnGPU.H, pEqnGPU.H}
  - 脚本：run/scripts/{run_gpu_parity.sh, benchmark_gpu_speed.sh}
  - 修复（通量一致性）：applications/solvers/incompressible/pimpleFoamGPU/pEqnGPU.H:517

  这份 PR 将“正确性、安全性与可观测性”整体建好，同时在算子/湍流/压力求解三条线上提供 GPU 路径与保守回退。要达成“GPU 端到端快于 CPU”的目标，下一阶段将聚焦“迭代
  数压缩＋编排与常驻优化”，在保持字段一致性的前提下系统性地降低压力环节成本并消除额外的 GPU 调度开销。